### PR TITLE
Add `_with` option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ for all the passed options.
   - `client`          Returns standalone compiled function
   - `delimiter`       Character to use with angle brackets for open/close
   - `debug`           Output generated function body
+  - `_with`           Whether or not to use `with() {}` constructs. If `false`
+                      then the locals will be stored in the `locals` object.
 
 ## Tags
 

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -274,8 +274,11 @@ Template.prototype = new function () {
       // FIXME: EtherpadLite accesses the old internal `buf` variable
       // in their bootstrap code: https://github.com/ether/etherpad-lite/issues/2437
       // Remove this bandaid ASAP
-      this.source = 'var buf = []; var __output = ""; with (locals) { ' + this.source;
-      this.source += '} buf = [__output]; return __output.trim();';
+      var appended = 'var buf = []; var __output = "";';
+      if (opts._with !== false) appended +=  ' with (locals) { ';
+      this.source  = appended + this.source;
+      if (opts._with !== false) this.source += '}';
+      this.source += 'buf = [__output]; return __output.trim();';
     }
 
     if (opts.compileDebug) {

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -90,6 +90,12 @@ suite('ejs.render(str, data)', function () {
     assert.equal(ejs.render('<p><%= name %></p>', {name: 'geddy'}),
         '<p>geddy</p>');
   });
+
+  test('accept locals without using with() {}', function () {
+    assert.equal(ejs.render('<p><%= locals.name %></p>', {name: 'geddy'},
+                            {_with: false}),
+        '<p>geddy</p>');
+  });
 });
 
 suite('ejs.renderFile(path, options, fn)', function () {
@@ -106,6 +112,18 @@ suite('ejs.renderFile(path, options, fn)', function () {
   test('accept locals', function(done) {
     var data =  {name: 'fonebone'}
       , options = {delimiter: '$'};
+    ejs.renderFile('test/fixtures/user.ejs', data, options, function(err, html) {
+      if (err) {
+        return done(err);
+      }
+      assert.equal(html, '<h1>fonebone</h1>');
+      done();
+    });
+  });
+
+  test('accept locals without using with() {}', function(done) {
+    var data =  {name: 'fonebone'}
+      , options = {delimiter: '$', _with: false};
     ejs.renderFile('test/fixtures/user.ejs', data, options, function(err, html) {
       if (err) {
         return done(err);

--- a/test/fixtures/user-no-with.ejs
+++ b/test/fixtures/user-no-with.ejs
@@ -1,0 +1,1 @@
+<h1><$= locals.name $></h1>


### PR DESCRIPTION
This option controls whether or not to use `with() {}` in the generated funcs. It is useful for performance purposes. EJS v1 had this option as well, albeit undocumented.