### PR TITLE
Move mocha opts to test/mocha.opts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "node": "*"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha --ui tdd --reporter spec"
+    "test": "./node_modules/mocha/bin/mocha"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--ui tdd
+--reporter spec


### PR DESCRIPTION
Less cluttered package.json. This has the additional benefit of being able to directly run `mocha` without `npm test`.