### PR TITLE
Fix `scope` handling

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -158,8 +158,8 @@ exports.render = function () {
   // 'scope' is 'context'
   // FIXME: Remove this in a future version
   if (opts.scope) {
-    opts.context = opts.scope;
-    delete opts.context;
+    if (!opts.context) opts.context = opts.scope;
+    delete opts.scope;
   }
 
   if (opts.cache) {


### PR DESCRIPTION
Also do not override `context`, which is the newer option.

Fixes #19.