### PR TITLE
Do not include __line in function unless compileDebug is true

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -501,7 +501,7 @@ Template.prototype = new function () {
         }
     }
 
-    if (newLineCount) {
+    if (self.opts.compileDebug && newLineCount) {
       this.currentLine += newLineCount;
       this.source += ';__line = ' + this.currentLine + ';';
     }


### PR DESCRIPTION
With or without this patch, `compileDebug === true`:

```js
var __line = 1
  , __lines = "<ul>\n  <% if (users) { %>\n    <p>Has users</p>\n  <% } %>\n</ul>"
  , __filename = undefined;
try {
  var __output = "";
  with (locals || {}) {
    ;__output += "<ul>\n  ";;
    __line = 2;;
    if (users) {
      ;__output += "\n    <p>Has users</p>\n  ";;
      __line = 4;;
    }
    ;__output += "\n</ul>";;
    __line = 5;
  }
  return __output.trim();
}
catch (e) {
  rethrow(e, __lines, __filename, __line);
}
```

Without this patch, `compileDebug === false`:

```js
var __output = "";
with (locals || {}) {
  ;__output += "<ul>\n  ";;
  __line = 2;;
  if (users) {
    ;__output += "\n    <p>Has users</p>\n  ";;
    __line = 4;;
  }
  ;__output += "\n</ul>";;
  __line = 5;
}
return __output.trim();
```

The `__line`s are completely useless.

With this patch, `compileDebug === false`:

```js
var __output = "";
with (locals || {}) {
  ;__output += "<ul>\n  ";;
  if (users) {
    ;__output += "\n    <p>Has users</p>\n  ";;
  }
  ;__output += "\n</ul>";
}
return __output.trim();
```