### PR TITLE
Optimize

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -248,7 +248,7 @@ Template.prototype = new function () {
 
     if (!this.source) {
       this.generateSource();
-      var prepended = 'var __output = "";';
+      var prepended = 'var __output = [];';
       if (opts._with !== false) {
         prepended +=  ' with (locals || {}) { ';
       }
@@ -256,7 +256,7 @@ Template.prototype = new function () {
       if (opts._with !== false) {
         this.source += '}';
       }
-      this.source += ';return __output.trim();';
+      this.source += ';return __output.join("").trim();';
     }
 
     if (opts.compileDebug) {
@@ -400,7 +400,7 @@ Template.prototype = new function () {
       // Escape double-quotes
       // - this will be the delimiter during execution
       line = line.replace(/"/g, '\\"');
-      self.source += ';__output += "' + line + '";';
+      self.source += ';__output.push("' + line + '");';
     }
 
     newLineCount = (line.split('\n').length - 1);
@@ -420,7 +420,7 @@ Template.prototype = new function () {
         break;
       case '<' + d + d:
         this.mode = Template.modes.LITERAL;
-        this.source += ';__output += "' + line.replace('<' + d + d, '<' + d) + '";';
+        this.source += ';__output.push("' + line.replace('<' + d + d, '<' + d) + '");';
         break;
       case d + '>':
       case '-' + d + '>':
@@ -453,16 +453,16 @@ Template.prototype = new function () {
               // Add the exec'd, escaped result to the output
               // Have to prevent the string-coercion of `undefined` and `null`
               // in the `escape` function -- making a `join` call like below unnecessary
-              this.source += ';__output += escape(' +
-                line.replace(_TRAILING_SEMCOL, '').trim() + ')';
+              this.source += ';__output.push(escape(' +
+                line.replace(_TRAILING_SEMCOL, '').trim() + '))';
               break;
             // Exec and output
             case Template.modes.RAW:
               // Add the exec'd result to the output
               // Using `join` here prevents string-coercion of `undefined` and `null`
               // without filtering out falsey values like zero
-              this.source += ';__output = [__output, ' +
-                line.replace(_TRAILING_SEMCOL, '').trim() + '].join("")';
+              this.source += ';__output.push(' +
+                line.replace(_TRAILING_SEMCOL, '').trim() + ')';
               break;
             case Template.modes.COMMENT:
               // Do nothing

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -276,7 +276,15 @@ Template.prototype = new function () {
     }
 
     if (opts.client) {
-      src = 'escape = escape || ' + escape.toString() + ';\n' + src;
+      if (escape !== utils.escapeXML) {
+        src = 'escape = escape || ' + escape.toString() + ';\n' + src;
+      }
+      else {
+        src = utils.escapeFuncStr
+            + 'escape = escape || '
+            + escape.toString() + ';\n'
+            + src;
+      }
       if (opts.compileDebug) {
         src = 'rethrow = rethrow || ' + rethrow.toString() + ';\n' + src;
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,19 +28,32 @@ exports.escapeRegExpChars = function (string) {
   return String(string).replace(regExpChars, '\\$&');
 };
 
+var encodeHTMLRules = {
+      '&': '&amp;'
+    , '<': '&lt;'
+    , '>': '&gt;'
+    , '"': '&#34;'
+    , "'": '&#39;'
+    }
+  , matchHTML = /[&<>\'"]/g;
+
+exports.escapeFuncStr =
+  'var encodeHTMLRules = {'
++       '"&": "&amp;"'
++     ', "<": "&lt;"'
++     ', ">": "&gt;"'
++     ', \'"\': "&#34;"'
++     ', "\'": "&#39;"'
++     '}'
++   ', matchHTML = /[&<>\'"]/g;';
+
 exports.escapeXML = function (markup) {
-  // Handle stupid JS `undefined` and `null`
-  // Yes, we want double-equal here to catch both
-  // jshint eqnull: true
-  if (markup == null) {
-    return '';
-  }
-  return String(markup)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/'/g, '&#39;')
-    .replace(/"/g, '&quot;');
+  return markup == undefined
+    ? ''
+    : String(markup)
+        .replace(matchHTML, function(m) {
+          return encodeHTMLRules[m] || m;
+        });
 };
 
 exports.shallowCopy = function (to, from) {


### PR DESCRIPTION
This gives a nice 30% speed up when using `with () {}`, and 80% speed up when not using `with () {}`.

I agree that the client mode is a little ugly, but that's what's necessary to get the speed up.