### PR TITLE
Allow to override handleCache()

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -50,7 +50,7 @@ exports.resolveInclude = function(name, filename) {
 // `template` is the string of EJS to compile.
 // If template is undefined then the file specified in options.filename is
 // read.
-function handleCache(options, template) {
+exports.handleCache = function(options, template) {
   var fn
     , path = options.filename
     , hasTemplate = template !== undefined;
@@ -87,7 +87,7 @@ function includeFile(path, options) {
     throw new Error('`include` requires the \'filename\' option.');
   }
   opts.filename = exports.resolveInclude(path, opts.filename);
-  return handleCache(opts);
+  return exports.handleCache(opts);
 }
 
 function includeSource(path, options) {
@@ -169,7 +169,7 @@ exports.render = function (template, data, opts) {
     cpOptsInData(data, opts);
   }
 
-  fn = handleCache(opts, template);
+  fn = exports.handleCache(opts, template);
   return fn.call(opts.context, data);
 };
 
@@ -192,7 +192,7 @@ exports.renderFile = function () {
   opts.filename = path;
 
   try {
-    result = handleCache(opts)(data);
+    result = exports.handleCache(opts)(data);
   }
   catch(err) {
     return process.nextTick(function () {


### PR DESCRIPTION
For pure front-end apps, it would be handy to be allowed to override the handleCache function

Created from https://github.com/mde/ejs/pull/58 but removed the version update.