### PR TITLE
Don't .trim() unconditionally

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -28,7 +28,8 @@ var fs = require('fs')
   , _OPTS = [ 'cache', 'filename', 'delimiter', 'scope', 'context'
             , 'debug', 'compileDebug', 'client', '_with'
             ]
-  , _TRAILING_SEMCOL = /;\s*$/;
+  , _TRAILING_SEMCOL = /;\s*$/
+  , _BOM = /^\uFEFF/;
 
 exports.localsName = _DEFAULT_LOCALS_NAME;
 
@@ -64,7 +65,7 @@ function handleCache(options, template) {
       return fn;
     }
     if (!hasTemplate) {
-      template = fs.readFileSync(path).toString();
+      template = fs.readFileSync(path).toString().replace(_BOM, '');
     }
   }
   else if (!hasTemplate) {
@@ -72,9 +73,9 @@ function handleCache(options, template) {
       throw new Error('Internal EJS error: no file name or template '
                     + 'provided');
     }
-    template = fs.readFileSync(path).toString();
+    template = fs.readFileSync(path).toString().replace(_BOM, '');
   }
-  fn = exports.compile(template.trim(), options);
+  fn = exports.compile(template, options);
   if (options.cache) {
     jsCache[path] = fn;
   }
@@ -98,7 +99,7 @@ function includeSource(path, options) {
     throw new Error('`include` requires the \'filename\' option.');
   }
   includePath = exports.resolveInclude(path, opts.filename);
-  template = fs.readFileSync(includePath).toString().trim();
+  template = fs.readFileSync(includePath).toString().replace(_BOM, '');
 
   opts.filename = includePath;
   var templ = new Template(template, opts);
@@ -261,7 +262,7 @@ Template.prototype = new function () {
       if (opts._with !== false) {
         this.source += '  }' + '\n';
       }
-      this.source += '  return __output.join("").trim();' + '\n';
+      this.source += '  return __output.join("");' + '\n';
     }
 
     if (opts.compileDebug) {
@@ -512,7 +513,7 @@ if (require.extensions) {
           filename: filename
         , client: true
         }
-      , template = fs.readFileSync(filename).toString().trim()
+      , template = fs.readFileSync(filename).toString()
       , fn = compile(template, options);
     module._compile('module.exports = ' + fn.toString() + ';', filename);
   };

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -233,7 +233,7 @@ suite('ejs.renderFile(path, [data], [options], fn)', function () {
       if (err) {
         return done(err);
       }
-      assert.equal(html, '<h1>fonebone</h1>');
+      assert.equal(html, '<h1>fonebone</h1>\n');
       done();
     });
   });
@@ -251,7 +251,7 @@ suite('ejs.renderFile(path, [data], [options], fn)', function () {
         doneCount = 2;
         return done(err);
       }
-      assert.equal(html, '<h1>fonebone</h1>');
+      assert.equal(html, '<h1>fonebone</h1>\n');
       doneCount++;
       if (doneCount === 2) {
         done();
@@ -542,7 +542,7 @@ suite('include()', function () {
     assert.equal(
       ejs.render('<%- include("fixtures/includes/bom.ejs") %>',
         {}, {filename: path.join(__dirname, 'f.ejs')}),
-      '<p>This is a file with BOM.</p>');
+      '<p>This is a file with BOM.</p>\n');
   });
 
   test('include ejs with locals', function () {
@@ -650,7 +650,7 @@ suite('preprocessor include', function () {
     assert.equal(
       ejs.render('<% include fixtures/includes/bom.ejs %>',
         {}, {filename: path.join(__dirname, 'f.ejs')}),
-      '<p>This is a file with BOM.</p>');
+      '<p>This is a file with BOM.</p>\n');
   });
 
   test('work when nested', function () {

--- a/test/fixtures/include-simple.html
+++ b/test/fixtures/include-simple.html
@@ -1,3 +1,4 @@
 <ul>
   <p>Hello world!</p>
+
 </ul>

--- a/test/fixtures/include.css.html
+++ b/test/fixtures/include.css.html
@@ -1,3 +1,4 @@
 <style>body {
   foo: 'bar';
-}</style>
+}
+</style>

--- a/test/fixtures/include.html
+++ b/test/fixtures/include.html
@@ -1,9 +1,12 @@
 <ul>
   
     <li>geddy</li>
+
   
     <li>neil</li>
+
   
     <li>alex</li>
+
   
 </ul>

--- a/test/fixtures/include_preprocessor.css.html
+++ b/test/fixtures/include_preprocessor.css.html
@@ -1,3 +1,4 @@
 <style>body {
   foo: 'bar';
-}</style>
+}
+</style>

--- a/test/fixtures/include_preprocessor.html
+++ b/test/fixtures/include_preprocessor.html
@@ -1,9 +1,12 @@
 <ul>
   
     <li>geddy</li>
+
   
     <li>neil</li>
+
   
     <li>alex</li>
+
   
 </ul>


### PR DESCRIPTION
Fixes #60.

Q: is this a breaking change? Should we maintain compat with 2.x behavior or 1.x behavior?