### PR TITLE
Override escape's toString() instead of special casing it

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -446,13 +446,7 @@ Template.prototype = {
     }
 
     if (opts.client) {
-      if (escape !== utils.escapeXML) {
-        src = 'escape = escape || ' + escape.toString() + ';' + '\n' + src;
-      }
-      else {
-        src = utils.escapeFuncStr
-            + 'escape = escape || ' + escape.toString() + ';' + '\n' + src;
-      }
+      src = 'escape = escape || ' + escape.toString() + ';' + '\n' + src;
       if (opts.compileDebug) {
         src = 'rethrow = rethrow || ' + rethrow.toString() + ';' + '\n' + src;
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,7 +62,7 @@ var _ENCODE_HTML_RULES = {
  * @type {String}
  */
 
-exports.escapeFuncStr =
+var escapeFuncStr =
   'var _ENCODE_HTML_RULES = {\n'
 + '      "&": "&amp;"\n'
 + '    , "<": "&lt;"\n'
@@ -90,6 +90,9 @@ exports.escapeXML = function (markup) {
         .replace(_MATCH_HTML, function(m) {
           return _ENCODE_HTML_RULES[m] || m;
         });
+};
+exports.escapeXML.toString = function () {
+  return Function.prototype.toString.call(this) + ';\n' + escapeFuncStr
 };
 
 /**


### PR DESCRIPTION
One hack for another, which one is better?