### PR TITLE
* store compiled templates in the cache right away

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -466,6 +466,10 @@ Template.prototype = {
       throw e;
     }
 
+    if (opts.cache && opts.filename) {
+      exports.cache.set(opts.filename, fn);
+    }
+
     if (opts.client) {
       fn.dependencies = this.dependencies;
       return fn;

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -419,6 +419,22 @@ suite('cache specific', function () {
 
     ejs.cache = oldCache;
   });
+
+  test('cached includes', function () {
+
+    var oldCache = ejs.cache;
+    ejs.cache = LRU(3);
+    var fakeName = process.cwd()+'/included.ejs';
+
+    var t1 = ejs.compile('<%- include("included");%>', {cache:true,filename:'top'});
+    ejs.compile('included', {cache:true,filename:fakeName});
+    assert.equal(t1().trim(), "included");
+    ejs.compile('included-changed', {cache:true,filename:fakeName});
+    assert.equal(t1().trim(), "included-changed");
+
+    ejs.cache = oldCache;
+  });
+
 });
 
 suite('<%', function () {

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -426,7 +426,7 @@ suite('cache specific', function () {
     ejs.cache = LRU(3);
     var fakeName = process.cwd()+'/included.ejs';
 
-    var t1 = ejs.compile('<%- include("included");%>', {cache:true,filename:'top'});
+    var t1 = ejs.compile('<%- include("included") %>', {cache:true,filename:'top'});
     ejs.compile('included', {cache:true,filename:fakeName});
     assert.equal(t1().trim(), "included");
     ejs.compile('included-changed', {cache:true,filename:fakeName});


### PR DESCRIPTION
It seems that the only way the file can truly be cached is when it's actually loaded by EJS from F/S. Anything that is compile()'d is never cached. Without explicitly meddling with the cache, it's also not possible to update the cache.

This suggests to store compile()'d templates in the cache if `filename` and `cache` options are set. This allows to update the cache.

Thank you.
