### PR TITLE
IIFE inside `with` for better minification

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -415,15 +415,22 @@ Template.prototype = {
     }
     if (!this.source) {
       this.generateSource();
-      var prepended = '  var __output = [];' + '\n';
+
+      var prepended = ''
+        , appended = '';
+
       if (opts._with !== false) {
-        prepended +=  '  with (' + exports.localsName + ' || {}) {' + '\n';
+        prepended += '  with (' + exports.localsName + ' || {}) {' + '\n';
+        prepended += '    return (function(){' + '\n';
+        appended  += '    }());' + '\n'; // closes IIFE
+        appended  += '  }' + '\n'; // closes `with`
       }
-      this.source  = prepended + this.source;
-      if (opts._with !== false) {
-        this.source += '  }' + '\n';
-      }
-      this.source += '  return __output.join("");' + '\n';
+
+      prepended += '  var __output = [];' + '\n';
+      appended   = '  return __output.join("");' + '\n' + appended;
+
+      this.source = prepended + this.source + appended;
+
     }
 
     if (opts.compileDebug) {


### PR DESCRIPTION
Progress for #83.

Should I even bother with unit tests for this change? Is there even a reasonable way to achieve them? Either way, existing ones pass, and also our internal systems pass too, using modified code.

IIFE is 24 bytes, but when minfied, `__output` becomes 1 byte instead of 8, and it's repeated at least thrice - `var`, `return` and at least one `push`, so no harm done.
