### PR TITLE
`__pushToOutput()` minifies better than `__output.push()`

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -426,7 +426,7 @@ Template.prototype = {
         appended  += '  }' + '\n'; // closes `with`
       }
 
-      prepended += '  var __output = [];' + '\n';
+      prepended += '  var __output = [], __pushToOutput = __output.push.bind(__output);' + '\n';
       appended   = '  return __output.join("");' + '\n' + appended;
 
       this.source = prepended + this.source + appended;
@@ -592,7 +592,7 @@ Template.prototype = {
       // Escape double-quotes
       // - this will be the delimiter during execution
       line = line.replace(/"/g, '\\"');
-      self.source += '    ; __output.push("' + line + '")' + '\n';
+      self.source += '    ; __pushToOutput("' + line + '")' + '\n';
     }
 
     newLineCount = (line.split('\n').length - 1);
@@ -612,7 +612,7 @@ Template.prototype = {
         break;
       case '<' + d + d:
         this.mode = Template.modes.LITERAL;
-        this.source += '    ; __output.push("' + line.replace('<' + d + d, '<' + d) + '")' + '\n';
+        this.source += '    ; __pushToOutput("' + line.replace('<' + d + d, '<' + d) + '")' + '\n';
         break;
       case d + '>':
       case '-' + d + '>':
@@ -642,12 +642,12 @@ Template.prototype = {
               break;
             // Exec, esc, and output
             case Template.modes.ESCAPED:
-              this.source += '    ; __output.push(escape(' +
+              this.source += '    ; __pushToOutput(escape(' +
                 line.replace(_TRAILING_SEMCOL, '').trim() + '))' + '\n';
               break;
             // Exec and output
             case Template.modes.RAW:
-              this.source += '    ; __output.push(' +
+              this.source += '    ; __pushToOutput(' +
                 line.replace(_TRAILING_SEMCOL, '').trim() + ')' + '\n';
               break;
             case Template.modes.COMMENT:

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -426,7 +426,7 @@ Template.prototype = {
         appended  += '  }' + '\n'; // closes `with`
       }
 
-      prepended += '  var __output = [], __pushToOutput = __output.push.bind(__output);' + '\n';
+      prepended += '  var __output = [], __append = __output.push.bind(__output);' + '\n';
       appended   = '  return __output.join("");' + '\n' + appended;
 
       this.source = prepended + this.source + appended;
@@ -592,7 +592,7 @@ Template.prototype = {
       // Escape double-quotes
       // - this will be the delimiter during execution
       line = line.replace(/"/g, '\\"');
-      self.source += '    ; __pushToOutput("' + line + '")' + '\n';
+      self.source += '    ; __append("' + line + '")' + '\n';
     }
 
     newLineCount = (line.split('\n').length - 1);
@@ -612,7 +612,7 @@ Template.prototype = {
         break;
       case '<' + d + d:
         this.mode = Template.modes.LITERAL;
-        this.source += '    ; __pushToOutput("' + line.replace('<' + d + d, '<' + d) + '")' + '\n';
+        this.source += '    ; __append("' + line.replace('<' + d + d, '<' + d) + '")' + '\n';
         break;
       case d + '>':
       case '-' + d + '>':
@@ -642,12 +642,12 @@ Template.prototype = {
               break;
             // Exec, esc, and output
             case Template.modes.ESCAPED:
-              this.source += '    ; __pushToOutput(escape(' +
+              this.source += '    ; __append(escape(' +
                 line.replace(_TRAILING_SEMCOL, '').trim() + '))' + '\n';
               break;
             // Exec and output
             case Template.modes.RAW:
-              this.source += '    ; __pushToOutput(' +
+              this.source += '    ; __append(' +
                 line.replace(_TRAILING_SEMCOL, '').trim() + ')' + '\n';
               break;
             case Template.modes.COMMENT:


### PR DESCRIPTION
Progress for #83 

This might have an effect on performance (I think I've seen something somewhere about `bind` being slow-ish) and also won't render on IE8 without a `bind` shim - I'm using this version and all tests pass in our system: https://github.com/facebook/react/blob/master/src/test/phantomjs-shims.js
