### PR TITLE
Add Thinkful live help sessions badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Embedded JavaScript templates
 
 [![Build Status](https://img.shields.io/travis/mde/ejs/master.svg?style=flat)](https://travis-ci.org/mde/ejs)
 [![Developing Dependencies](https://img.shields.io/david/dev/mde/ejs.svg?style=flat)](https://david-dm.org/mde/ejs#info=devDependencies)
+[![Pair on This](https://tf-assets-staging.s3.amazonaws.com/badges/thinkful_repo_badge.svg)](http://start.thinkful.com/node/?utm_source=github&utm_medium=badge&utm_campaign=ejs)
 
 ## Installation
 


### PR DESCRIPTION
Hi @mde — as promised, pull request to add a Thinkful badge to the README. Following up on mde/ejs-site to add a support section to http://ejs.co/ too