### PR TITLE
Restoring IIFE, so that vars can be minimized inside the `with`

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -421,12 +421,14 @@ Template.prototype = {
 
     if (!this.source) {
       this.generateSource();
-      prepended += '  var __output = [], __append = __output.push.bind(__output);' + '\n';
       if (opts._with !== false) {
-        prepended +=  '  with (' + exports.localsName + ' || {}) {' + '\n';
-        appended += '  }' + '\n';
+        prepended += '  with (' + exports.localsName + ' || {}) {' + '\n';
+        prepended += '    return function(){' + '\n';
+        appended  += '    }.apply(this);' + '\n';
+        appended  += '  }' + '\n';
       }
-      appended += '  return __output.join("");' + '\n';
+      prepended += '  var __output = [], __append = __output.push.bind(__output);' + '\n';
+      appended   = '  return __output.join("");' + '\n' + appended;
       this.source = prepended + this.source + appended;
     }
 


### PR DESCRIPTION
Invoking IIFE not via simple `()` call, but rather via `.apply(this)` to ensure correct context