### PR TITLE
Adding support for Express 4 multiple views folders

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -164,12 +164,15 @@ function handleCache(options, template) {
  */
 
 function includeFile(filename, options) {
-  var opts = utils.shallowCopy({}, options), viewPath, views = options.views;
-  if (views !== undefined) {
-    viewPath = views.find(function (path) {
-      return fs.existsSync(exports.resolveInclude(filename, path));
-    });
-    opts.filename = path.join(viewPath, filename);
+  var opts = utils.shallowCopy({}, options), filepath, views = options.views;
+  if(views !== undefined){
+    for(var i = 0, l = views.length; i < l; i++) {
+      filepath = exports.resolveInclude(filename, views[i]);
+      if(fs.existsSync(filepath)){
+        opts.filename = filepath;
+        break;
+      }
+    }
   } else {
     if (!opts.filename) {
       throw new Error('`include` requires the \'filename\' option.');
@@ -191,17 +194,17 @@ function includeFile(filename, options) {
 
 function includeSource(filename, options) {
   var opts = utils.shallowCopy({}, options)
-      , includePath
-      , viewPath
-      , template, views = options.views;
-  if (views !== undefined) {
-    viewPath = views.find(function (path) {
-      return fs.existsSync(exports.resolveInclude(filename, path));
-    });
-    includePath = path.join(viewPath, filename);
-
-    template = fs.readFileSync(includePath).toString().replace(_BOM, '');
-    opts.filename = includePath;
+    , includePath
+    , template, views = options.views;
+  if(views !== undefined){
+    for(var i = 0, l = views.length; i < l; i++) {
+      includePath = exports.resolveInclude(filename, views[i]);
+      if(fs.existsSync(includePath)){
+        template = fs.readFileSync(includePath).toString().replace(_BOM, '');
+        opts.filename = includePath;
+        break;
+      }
+    }
   } else {
     if (!opts.filename) {
       throw new Error('`include` requires the \'filename\' option.');

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 
 'use strict';
 
@@ -45,18 +45,18 @@
  */
 
 var fs = require('fs')
-  , path = require('path')
-  , utils = require('./utils')
-  , scopeOptionWarned = false
-  , _VERSION_STRING = require('../package.json').version
-  , _DEFAULT_DELIMITER = '%'
-  , _DEFAULT_LOCALS_NAME = 'locals'
-  , _REGEX_STRING = '(<%%|<%=|<%-|<%_|<%#|<%|%>|-%>|_%>)'
-  , _OPTS = [ 'cache', 'filename', 'delimiter', 'scope', 'context'
-            , 'debug', 'compileDebug', 'client', '_with', 'rmWhitespace'
-            ]
-  , _TRAILING_SEMCOL = /;\s*$/
-  , _BOM = /^\uFEFF/;
+    , path = require('path')
+    , utils = require('./utils')
+    , scopeOptionWarned = false
+    , _VERSION_STRING = require('../package.json').version
+    , _DEFAULT_DELIMITER = '%'
+    , _DEFAULT_LOCALS_NAME = 'locals'
+    , _REGEX_STRING = '(<%%|<%=|<%-|<%_|<%#|<%|%>|-%>|_%>)'
+    , _OPTS = ['cache', 'filename', 'delimiter', 'scope', 'context'
+  , 'debug', 'compileDebug', 'client', '_with', 'rmWhitespace'
+]
+    , _TRAILING_SEMCOL = /;\s*$/
+    , _BOM = /^\uFEFF/;
 
 /**
  * EJS template function cache. This can be a LRU object from lru-cache NPM
@@ -89,7 +89,7 @@ exports.localsName = _DEFAULT_LOCALS_NAME;
  * @return {String}
  */
 
-exports.resolveInclude = function(name, filepath) {
+exports.resolveInclude = function (name, filepath) {
   var extname = path.extname
       , resolve = path.resolve
       , includePath = resolve(filepath, name)
@@ -120,8 +120,8 @@ exports.resolveInclude = function(name, filepath) {
 
 function handleCache(options, template) {
   var fn
-    , path = options.filename
-    , hasTemplate = arguments.length > 1;
+      , path = options.filename
+      , hasTemplate = arguments.length > 1;
 
   if (options.cache) {
     if (!path) {
@@ -139,7 +139,7 @@ function handleCache(options, template) {
     // istanbul ignore if: should not happen at all
     if (!path) {
       throw new Error('Internal EJS error: no file name or template '
-                    + 'provided');
+          + 'provided');
     }
     template = fs.readFileSync(path).toString().replace(_BOM, '');
   }
@@ -164,15 +164,12 @@ function handleCache(options, template) {
  */
 
 function includeFile(filename, options) {
-  var opts = utils.shallowCopy({}, options), filepath, views = options.views;
-  if(views !== undefined){
-    for(var i = 0, l = views.length; i < l; i++) {
-      filepath = exports.resolveInclude(filename, views[i]);
-      if(fs.existsSync(filepath)){
-        opts.filename = filepath;
-        break;
-      }
-    }
+  var opts = utils.shallowCopy({}, options), viewPath, views = options.views;
+  if (views !== undefined) {
+    viewPath = views.find(function (path) {
+      return fs.existsSync(exports.resolveInclude(filename, path));
+    });
+    opts.filename = path.join(viewPath, filename);
   } else {
     if (!opts.filename) {
       throw new Error('`include` requires the \'filename\' option.');
@@ -194,17 +191,17 @@ function includeFile(filename, options) {
 
 function includeSource(filename, options) {
   var opts = utils.shallowCopy({}, options)
-    , includePath
-    , template, views = options.views;
-  if(views !== undefined){
-    for(var i = 0, l = views.length; i < l; i++) {
-      includePath = exports.resolveInclude(filename, views[i]);
-      if(fs.existsSync(includePath)){
-        template = fs.readFileSync(includePath).toString().replace(_BOM, '');
-        opts.filename = includePath;
-        break;
-      }
-    }
+      , includePath
+      , viewPath
+      , template, views = options.views;
+  if (views !== undefined) {
+    viewPath = views.find(function (path) {
+      return fs.existsSync(exports.resolveInclude(filename, path));
+    });
+    includePath = path.join(viewPath, filename);
+
+    template = fs.readFileSync(includePath).toString().replace(_BOM, '');
+    opts.filename = includePath;
   } else {
     if (!opts.filename) {
       throw new Error('`include` requires the \'filename\' option.');
@@ -233,26 +230,26 @@ function includeSource(filename, options) {
  * @static
  */
 
-function rethrow(err, str, filename, lineno){
+function rethrow(err, str, filename, lineno) {
   var lines = str.split('\n')
-    , start = Math.max(lineno - 3, 0)
-    , end = Math.min(lines.length, lineno + 3);
+      , start = Math.max(lineno - 3, 0)
+      , end = Math.min(lines.length, lineno + 3);
 
   // Error context
-  var context = lines.slice(start, end).map(function (line, i){
+  var context = lines.slice(start, end).map(function (line, i) {
     var curr = i + start + 1;
     return (curr == lineno ? ' >> ' : '    ')
-      + curr
-      + '| '
-      + line;
+        + curr
+        + '| '
+        + line;
   }).join('\n');
 
   // Alter exception message
   err.path = filename;
   err.message = (filename || 'ejs') + ':'
-    + lineno + '\n'
-    + context + '\n\n'
-    + err.message;
+      + lineno + '\n'
+      + context + '\n\n'
+      + err.message;
 
   throw err;
 }
@@ -296,7 +293,7 @@ exports.compile = function compile(template, opts) {
   // 'scope' is 'context'
   // FIXME: Remove this in a future version
   if (opts && opts.scope) {
-    if (!scopeOptionWarned){
+    if (!scopeOptionWarned) {
       console.warn('`scope` option is deprecated and will be removed in EJS 3');
       scopeOptionWarned = true;
     }
@@ -325,7 +322,6 @@ exports.compile = function compile(template, opts) {
 exports.render = function (template, data, opts) {
   data = data || {};
   opts = opts || {};
-  var fn;
 
   // No options object -- if there are optiony names
   // in the data, copy them to options
@@ -351,11 +347,11 @@ exports.render = function (template, data, opts) {
 
 exports.renderFile = function () {
   var args = Array.prototype.slice.call(arguments)
-    , path = args.shift()
-    , cb = args.pop()
-    , data = args.shift() || {}
-    , opts = args.pop() || {}
-    , result;
+      , path = args.shift()
+      , cb = args.pop()
+      , data = args.shift() || {}
+      , opts = args.pop() || {}
+      , result;
 
   // Don't pollute passed in opts obj with new vals
   opts = utils.shallowCopy({}, opts);
@@ -365,7 +361,7 @@ exports.renderFile = function () {
   if (arguments.length == 3) {
     cpOptsInData(data, opts);
   }
-  if(data.settings && data.settings.views && utils.isArray(data.settings.views) && data.settings.views.length > 1){
+  if (data.settings && data.settings.views && utils.isArray(data.settings.views)) {
     opts.views = data.settings.views;
   }
   opts.filename = path;
@@ -373,7 +369,7 @@ exports.renderFile = function () {
   try {
     result = handleCache(opts)(data);
   }
-  catch(err) {
+  catch (err) {
     return cb(err);
   }
   return cb(null, result);
@@ -415,44 +411,44 @@ function Template(text, opts) {
 
 Template.modes = {
   EVAL: 'eval'
-, ESCAPED: 'escaped'
-, RAW: 'raw'
-, COMMENT: 'comment'
-, LITERAL: 'literal'
+  , ESCAPED: 'escaped'
+  , RAW: 'raw'
+  , COMMENT: 'comment'
+  , LITERAL: 'literal'
 };
 
 Template.prototype = {
   createRegex: function () {
     var str = _REGEX_STRING
-      , delim = utils.escapeRegExpChars(this.opts.delimiter);
+        , delim = utils.escapeRegExpChars(this.opts.delimiter);
     str = str.replace(/%/g, delim);
     return new RegExp(str);
   }
 
-, compile: function () {
+  , compile: function () {
     var src
-      , fn
-      , opts = this.opts
-      , prepended = ''
-      , appended = ''
-      , escape = opts.escapeFunction;
+        , fn
+        , opts = this.opts
+        , prepended = ''
+        , appended = ''
+        , escape = opts.escapeFunction;
 
     if (opts.rmWhitespace) {
       // Have to use two separate replace here as `^` and `$` operators don't
       // work well with `\r`.
       this.templateText =
-        this.templateText.replace(/\r/g, '').replace(/^\s+|\s+$/gm, '');
+          this.templateText.replace(/\r/g, '').replace(/^\s+|\s+$/gm, '');
     }
 
     // Slurp spaces and tabs before <%_ and after _%>
     this.templateText =
-      this.templateText.replace(/[ \t]*<%_/gm, '<%_').replace(/_%>[ \t]*/gm, '_%>');
+        this.templateText.replace(/[ \t]*<%_/gm, '<%_').replace(/_%>[ \t]*/gm, '_%>');
 
     if (!this.source) {
       this.generateSource();
       prepended += '  var __output = [], __append = __output.push.bind(__output);' + '\n';
       if (opts._with !== false) {
-        prepended +=  '  with (' + exports.localsName + ' || {}) {' + '\n';
+        prepended += '  with (' + exports.localsName + ' || {}) {' + '\n';
         appended += '  }' + '\n';
       }
       appended += '  return __output.join("");' + '\n';
@@ -463,7 +459,7 @@ Template.prototype = {
       src = 'var __line = 1' + '\n'
           + '  , __lines = ' + JSON.stringify(this.templateText) + '\n'
           + '  , __filename = ' + (opts.filename ?
-                JSON.stringify(opts.filename) : 'undefined') + ';' + '\n'
+              JSON.stringify(opts.filename) : 'undefined') + ';' + '\n'
           + 'try {' + '\n'
           + this.source
           + '} catch (e) {' + '\n'
@@ -488,7 +484,7 @@ Template.prototype = {
     try {
       fn = new Function(exports.localsName + ', escape, include, rethrow', src);
     }
-    catch(e) {
+    catch (e) {
       // istanbul ignore else
       if (e instanceof SyntaxError) {
         if (opts.filename) {
@@ -521,24 +517,24 @@ Template.prototype = {
     return returnedFn;
   }
 
-, generateSource: function () {
+  , generateSource: function () {
     var self = this
-      , matches = this.parseTemplateText()
-      , d = this.opts.delimiter;
+        , matches = this.parseTemplateText()
+        , d = this.opts.delimiter;
 
     if (matches && matches.length) {
       matches.forEach(function (line, index) {
         var opening
-          , closing
-          , include
-          , includeOpts
-          , includeSrc;
+            , closing
+            , include
+            , includeOpts
+            , includeSrc;
         // If this is an opening tag, check for closing tags
         // FIXME: May end up with some false positives here
         // Better to store modes as k/v with '<' + delimiter as key
         // Then this can simply check against the map
-        if ( line.indexOf('<' + d) === 0        // If it is a tag
-          && line.indexOf('<' + d + d) !== 0) { // and is not escaped
+        if (line.indexOf('<' + d) === 0        // If it is a tag
+            && line.indexOf('<' + d + d) !== 0) { // and is not escaped
           closing = matches[index + 2];
           if (!(closing == d + '>' || closing == '-' + d + '>' || closing == '_' + d + '>')) {
             throw new Error('Could not find matching close tag for "' + line + '".');
@@ -564,13 +560,13 @@ Template.prototype = {
     }
   }
 
-, parseTemplateText: function () {
+  , parseTemplateText: function () {
     var str = this.templateText
-      , pat = this.regex
-      , result = pat.exec(str)
-      , arr = []
-      , firstPos
-      , lastPos;
+        , pat = this.regex
+        , result = pat.exec(str)
+        , arr = []
+        , firstPos
+        , lastPos;
 
     while (result) {
       firstPos = result.index;
@@ -593,10 +589,10 @@ Template.prototype = {
     return arr;
   }
 
-, scanLine: function (line) {
+  , scanLine: function (line) {
     var self = this
-      , d = this.opts.delimiter
-      , newLineCount = 0;
+        , d = this.opts.delimiter
+        , newLineCount = 0;
 
     function _addOutput() {
       if (self.truncate) {
@@ -676,12 +672,12 @@ Template.prototype = {
             // Exec, esc, and output
             case Template.modes.ESCAPED:
               this.source += '    ; __append(escape(' +
-                line.replace(_TRAILING_SEMCOL, '').trim() + '))' + '\n';
+                  line.replace(_TRAILING_SEMCOL, '').trim() + '))' + '\n';
               break;
             // Exec and output
             case Template.modes.RAW:
               this.source += '    ; __append(' +
-                line.replace(_TRAILING_SEMCOL, '').trim() + ')' + '\n';
+                  line.replace(_TRAILING_SEMCOL, '').trim() + ')' + '\n';
               break;
             case Template.modes.COMMENT:
               // Do nothing
@@ -722,11 +718,11 @@ if (require.extensions) {
   require.extensions['.ejs'] = function (module, filename) {
     filename = filename || /* istanbul ignore next */ module.filename;
     var options = {
-          filename: filename
-        , client: true
-        }
-      , template = fs.readFileSync(filename).toString()
-      , fn = exports.compile(template, options);
+      filename: filename
+      , client: true
+    }
+        , template = fs.readFileSync(filename).toString()
+        , fn = exports.compile(template, options);
     module._compile('module.exports = ' + fn.toString() + ';', filename);
   };
 }

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -164,15 +164,15 @@ function handleCache(options, template) {
  */
 
 function includeFile(filename, options) {
-  var opts = utils.shallowCopy({}, options), filepath;
-  if(options.views !== undefined){
-    for(var i = 0; i < options.views.length; i++) {
-      filepath = exports.resolveInclude(filename, options.views[i]);
+  var opts = utils.shallowCopy({}, options), filepath, views = options.views;
+  if(views !== undefined){
+    for(var i = 0, l = views.length; i < l; i++) {
+      filepath = exports.resolveInclude(filename, views[i]);
       if(fs.existsSync(filepath)){
         opts.filename = filepath;
-        return handleCache(opts);
       }
     }
+    return handleCache(opts);
   } else {
     if (!opts.filename) {
       throw new Error('`include` requires the \'filename\' option.');

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -170,39 +170,51 @@ function includeFile(filename, options) {
       filepath = exports.resolveInclude(filename, views[i]);
       if(fs.existsSync(filepath)){
         opts.filename = filepath;
+        break;
       }
     }
-    return handleCache(opts);
   } else {
     if (!opts.filename) {
       throw new Error('`include` requires the \'filename\' option.');
     }
     opts.filename = exports.resolveInclude(filename, path.dirname(opts.filename));
-    return handleCache(opts);
   }
+  return handleCache(opts);
 }
 
 /**
  * Get the JavaScript source of an included file.
  *
  * @memberof module:ejs-internal
- * @param {String}  filePath    path for the specified file
+ * @param {String}  filename    path for the specified file
  * @param {Options} options compilation options
  * @return {String}
  * @static
  */
 
-function includeSource(filePath, options) {
+function includeSource(filename, options) {
   var opts = utils.shallowCopy({}, options)
     , includePath
-    , template;
-  if (!opts.filename) {
-    throw new Error('`include` requires the \'filename\' option.');
-  }
-  includePath = exports.resolveInclude(filePath, path.dirname(opts.filename));
-  template = fs.readFileSync(includePath).toString().replace(_BOM, '');
+    , template, views = options.views;
+  if(views !== undefined){
+    for(var i = 0, l = views.length; i < l; i++) {
+      includePath = exports.resolveInclude(filename, views[i]);
+      if(fs.existsSync(includePath)){
+        template = fs.readFileSync(includePath).toString().replace(_BOM, '');
+        opts.filename = includePath;
+        break;
+      }
+    }
+  } else {
+    if (!opts.filename) {
+      throw new Error('`include` requires the \'filename\' option.');
+    }
+    includePath = exports.resolveInclude(filename, path.dirname(opts.filename));
+    template = fs.readFileSync(includePath).toString().replace(_BOM, '');
 
-  opts.filename = includePath;
+    opts.filename = includePath;
+  }
+
   var templ = new Template(template, opts);
   templ.generateSource();
   return templ.source;

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -45,6 +45,7 @@
  */
 
 var fs = require('fs')
+  , path = require('path')
   , utils = require('./utils')
   , scopeOptionWarned = false
   , _VERSION_STRING = require('../package.json').version
@@ -84,17 +85,15 @@ exports.localsName = _DEFAULT_LOCALS_NAME;
  * specified path.
  *
  * @param {String} name     specified path
- * @param {String} filename parent file path
+ * @param {String} filepath parent file path
  * @return {String}
  */
 
-exports.resolveInclude = function(name, filename) {
-  var path = require('path')
-    , dirname = path.dirname
-    , extname = path.extname
-    , resolve = path.resolve
-    , includePath = resolve(dirname(filename), name)
-    , ext = extname(name);
+exports.resolveInclude = function(name, filepath) {
+  var extname = path.extname
+      , resolve = path.resolve
+      , includePath = resolve(filepath, name)
+      , ext = extname(name);
   if (!ext) {
     includePath += '.ejs';
   }
@@ -157,40 +156,50 @@ function handleCache(options, template) {
  * If `options.cache` is `true`, then the template is cached.
  *
  * @memberof module:ejs-internal
- * @param {String}  path    path for the specified file
+ * @param {String}  filename    path for the specified file
  * @param {Options} options compilation options
  * @return {(TemplateFunction|ClientFunction)}
  * Depending on the value of `options.client`, either type might be returned
  * @static
  */
 
-function includeFile(path, options) {
-  var opts = utils.shallowCopy({}, options);
-  if (!opts.filename) {
-    throw new Error('`include` requires the \'filename\' option.');
+function includeFile(filename, options) {
+  var opts = utils.shallowCopy({}, options), filepath;
+  if(options.fileRoots !== undefined){
+    for(var i = 0; i < options.fileRoots.length; i++) {
+      filepath = exports.resolveInclude(filename, options.fileRoots[i]);
+      if(fs.existsSync(filepath)){
+        opts.filename = filepath;
+        return handleCache(opts);
+      }
+    }
+  } else {
+    if (!opts.filename) {
+      throw new Error('`include` requires the \'filename\' option.');
+    }
+    opts.filename = exports.resolveInclude(filename, path.dirname(opts.filename));
+    return handleCache(opts);
   }
-  opts.filename = exports.resolveInclude(path, opts.filename);
-  return handleCache(opts);
 }
 
 /**
  * Get the JavaScript source of an included file.
  *
  * @memberof module:ejs-internal
- * @param {String}  path    path for the specified file
+ * @param {String}  filePath    path for the specified file
  * @param {Options} options compilation options
  * @return {String}
  * @static
  */
 
-function includeSource(path, options) {
+function includeSource(filePath, options) {
   var opts = utils.shallowCopy({}, options)
     , includePath
     , template;
   if (!opts.filename) {
     throw new Error('`include` requires the \'filename\' option.');
   }
-  includePath = exports.resolveInclude(path, opts.filename);
+  includePath = exports.resolveInclude(filePath, path.dirname(opts.filename));
   template = fs.readFileSync(includePath).toString().replace(_BOM, '');
 
   opts.filename = includePath;
@@ -344,6 +353,9 @@ exports.renderFile = function () {
   if (arguments.length == 3) {
     cpOptsInData(data, opts);
   }
+  if(data.settings && data.settings.views && utils.isArray(data.settings.views) && data.settings.views.length > 1){
+    opts.fileRoots = data.settings.views;
+  }
   opts.filename = path;
 
   try {
@@ -383,6 +395,7 @@ function Template(text, opts) {
   options.context = opts.context;
   options.cache = opts.cache || false;
   options.rmWhitespace = opts.rmWhitespace;
+  options.fileRoots = opts.fileRoots;
   this.opts = options;
 
   this.regex = this.createRegex();
@@ -530,14 +543,13 @@ Template.prototype = {
                 '    ; })()' + '\n';
             self.source += includeSrc;
             self.dependencies.push(exports.resolveInclude(include[1],
-                includeOpts.filename));
+                path.dirname(includeOpts.filename)));
             return;
           }
         }
         self.scanLine(line);
       });
     }
-
   }
 
 , parseTemplateText: function () {

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -165,9 +165,9 @@ function handleCache(options, template) {
 
 function includeFile(filename, options) {
   var opts = utils.shallowCopy({}, options), filepath;
-  if(options.fileRoots !== undefined){
-    for(var i = 0; i < options.fileRoots.length; i++) {
-      filepath = exports.resolveInclude(filename, options.fileRoots[i]);
+  if(options.views !== undefined){
+    for(var i = 0; i < options.views.length; i++) {
+      filepath = exports.resolveInclude(filename, options.views[i]);
       if(fs.existsSync(filepath)){
         opts.filename = filepath;
         return handleCache(opts);
@@ -354,7 +354,7 @@ exports.renderFile = function () {
     cpOptsInData(data, opts);
   }
   if(data.settings && data.settings.views && utils.isArray(data.settings.views) && data.settings.views.length > 1){
-    opts.fileRoots = data.settings.views;
+    opts.views = data.settings.views;
   }
   opts.filename = path;
 
@@ -395,7 +395,7 @@ function Template(text, opts) {
   options.context = opts.context;
   options.cache = opts.cache || false;
   options.rmWhitespace = opts.rmWhitespace;
-  options.fileRoots = opts.fileRoots;
+  options.views = opts.views;
   this.opts = options;
 
   this.regex = this.createRegex();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,6 +26,8 @@
 
 var regExpChars = /[|\\{}()[\]^$+*?.]/g;
 
+exports.isArray = require('util').isArray;
+
 /**
  * Escape characters reserved in regular expressions.
  *

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "homepage": "https://github.com/mde/ejs",
   "dependencies": {},
   "devDependencies": {
-    "browserify": "^8.0.3",
-    "istanbul": "~0.3.5",
+    "browserify": "^12.0.1",
+    "istanbul": "~0.4.0",
     "jake": "^8.0.0",
     "jsdoc": "^3.3.0-beta1",
     "lru-cache": "^2.5.0",

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -726,6 +726,80 @@ suite('include()', function () {
     assert.equal(out, expected);
   });
 
+  test('support express multiple views folders, returns the first match', function (done) {
+    var data = {
+      viewsText: 'test',
+      settings: {
+        views: [
+          path.join(__dirname, 'fixtures/views'),
+          path.join(__dirname, 'fixtures')
+        ]
+      }
+    };
+    ejs.renderFile(path.join(__dirname, 'fixtures/views.ejs'), data, {}, function(error, data){
+      assert.ifError(error);
+      assert.equal('<div><p>custom test</p>\n</div>\n', data);
+      done()
+    });
+
+  });
+
+  test('support express multiple views folders, falls back to second if first is not available', function (done) {
+    var data = {
+      viewsText: 'test',
+      settings: {
+        views: [
+          path.join(__dirname, 'fixtures/nonexistent-folder'),
+          path.join(__dirname, 'fixtures')
+        ]
+      }
+    };
+    ejs.renderFile(path.join(__dirname, 'fixtures/views.ejs'), data, {}, function(error, data){
+      assert.ifError(error);
+      assert.equal('<div><p>global test</p>\n</div>\n', data);
+      done()
+    });
+
+  });
+
+  test('support express multiple views folders, also in old format', function (done) {
+    var data = {
+      viewsText: 'test',
+      settings: {
+        views: [
+          path.join(__dirname, 'fixtures/views'),
+          path.join(__dirname, 'fixtures')
+        ]
+      }
+    };
+    ejs.renderFile(path.join(__dirname, 'fixtures/views-old.ejs'), data, {}, function(error, data){
+      assert.ifError(error);
+      assert.equal('<div><p>custom test</p>\n</div>\n', data);
+      done()
+    });
+
+  });
+
+  test('support express multiple views folders, uses fallback also in old format', function (done) {
+    var data = {
+      viewsText: 'test',
+      settings: {
+        views: [
+          path.join(__dirname, 'fixtures/nonexistent-folder'),
+          path.join(__dirname, 'fixtures')
+        ]
+      }
+    };
+    ejs.renderFile(path.join(__dirname, 'fixtures/views-old.ejs'), data, {}, function(error, data){
+      assert.ifError(error);
+      assert.equal('<div><p>global test</p>\n</div>\n', data);
+      done()
+    });
+
+  });
+
+
+
 });
 
 suite('preprocessor include', function () {

--- a/test/fixtures/views-include.ejs
+++ b/test/fixtures/views-include.ejs
@@ -1,0 +1,1 @@
+<p>global <%= viewsText %></p>

--- a/test/fixtures/views-old.ejs
+++ b/test/fixtures/views-old.ejs
@@ -1,0 +1,1 @@
+<div><%- include views-include.ejs %></div>

--- a/test/fixtures/views.ejs
+++ b/test/fixtures/views.ejs
@@ -1,0 +1,1 @@
+<div><%- include('views-include.ejs', {viewsText: 'test'}) %></div>

--- a/test/fixtures/views/views-include.ejs
+++ b/test/fixtures/views/views-include.ejs
@@ -1,0 +1,1 @@
+<p>custom <%= viewsText %></p>


### PR DESCRIPTION
Since version 4.10 of Express you can set multiple views folders. Unfortunately all includes in EJS are still looked up relatively to the including template, which limits the use of this new feature, since all include files have to be inlined or copied over to the different views folders.

I updated the code to lookup include files in all views folders, loading the first occurrence found, but only in case settings.views, wich is passed in by express, is set and of type Array with a length greater then 1. 
