### PR TITLE
Feat: fileload should be independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ of the LRU.
 
 ## Custom FileLoader
 
-The default file loader is `fs.readFileSync`, if you want to customize, You can override the fileLoader method.
+The default file loader is `fs.readFileSync`, if you want to customize it, you can set ejs.fileLoader.
 
 ```javascript
 var ejs = require('ejs');

--- a/README.md
+++ b/README.md
@@ -162,6 +162,21 @@ If you want to clear the EJS cache, call `ejs.clearCache`. If you're using the
 LRU cache and need a different limit, simple reset `ejs.cache` to a new instance
 of the LRU.
 
+## Custom FileLoader
+
+The default file loader is `fs.readFileSync`, if you want to customize, You can override the fileLoader method.
+
+```javascript
+var ejs = require('ejs');
+var myFileLoad = function (filePath) {
+  return 'myFileLoad: ' + fs.readFileSync(filePath);
+};
+
+ejs.fileLoader = myFileLoad;
+```
+
+With this feature, you can preprocess the template before reading it.
+
 ## Layouts
 
 EJS does not specifically support blocks, but layouts can be implemented by

--- a/docs/jsdoc/fileLoader.jsdoc
+++ b/docs/jsdoc/fileLoader.jsdoc
@@ -1,0 +1,10 @@
+/**
+ * A file read function, similar to fs.readFileSync, this function
+ * can be read a file by path, return a string after processing
+ *
+ * @function
+ * @name fileLoader
+ * @param {String}   path the path of the file to be read
+ * @return {String|Object} the contents of the file as a string or objects that implement the toString() method
+ * @global
+ */

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -69,6 +69,17 @@ var _BOM = /^\uFEFF/;
 exports.cache = utils.cache;
 
 /**
+ * For security reasons, Sometimes the template file may have some
+ * pre-processing.For example, inserts some checking data in the form of
+ * time reading the html file.
+ *
+ * @type {Function}
+ * @public
+ */
+
+exports.fileLoader = fs.readFileSync;
+
+/**
  * Name of the object containing the locals.
  *
  * This variable is overridden by {@link Options}`.localsName` if it is not
@@ -154,7 +165,7 @@ function handleCache(options, template) {
       return func;
     }
     if (!hasTemplate) {
-      template = fs.readFileSync(filename).toString().replace(_BOM, '');
+      template = fileLoader(filename).toString().replace(_BOM, '');
     }
   }
   else if (!hasTemplate) {
@@ -163,13 +174,25 @@ function handleCache(options, template) {
       throw new Error('Internal EJS error: no file name or template '
                     + 'provided');
     }
-    template = fs.readFileSync(filename).toString().replace(_BOM, '');
+    template = fileLoader(filename).toString().replace(_BOM, '');
   }
   func = exports.compile(template, options);
   if (options.cache) {
     exports.cache.set(filename, func);
   }
   return func;
+}
+
+/**
+ * fileLoader is independent
+ *
+ * @param {String} filePath ejs file path.
+ * @return {String} The contents of the specified file.
+ * @static
+ */
+
+function fileLoader(filePath){
+  return exports.fileLoader(filePath);
 }
 
 /**
@@ -205,8 +228,8 @@ function includeSource(path, options) {
   var opts = utils.shallowCopy({}, options);
   var includePath;
   var template;
-  includePath = getIncludePath(path,opts);
-  template = fs.readFileSync(includePath).toString().replace(_BOM, '');
+  includePath = getIncludePath(path, opts);
+  template = fileLoader(includePath).toString().replace(_BOM, '');
   opts.filename = includePath;
   var templ = new Template(template, opts);
   templ.generateSource();
@@ -254,7 +277,7 @@ function rethrow(err, str, flnm, lineno, esc){
   throw err;
 }
 
-function stripSemi(str) {
+function stripSemi(str){
   return str.replace(/;(\s*$)/, '$1');
 }
 
@@ -335,7 +358,7 @@ exports.renderFile = function () {
   var cb = args.pop();
   var data = args.shift() || {};
   var opts = args.pop() || {};
-  var optsKeys =_OPTS.slice();
+  var optsKeys = _OPTS.slice();
   var result;
 
   // Don't pollute passed in opts obj with new vals
@@ -766,7 +789,7 @@ if (require.extensions) {
       filename: filename,
       client: true
     };
-    var template = fs.readFileSync(filename).toString();
+    var template = fileLoader(filename).toString();
     var fn = exports.compile(template, options);
     module._compile('module.exports = ' + fn.toString() + ';', filename);
   };

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -69,12 +69,10 @@ var _BOM = /^\uFEFF/;
 exports.cache = utils.cache;
 
 /**
- * For security reasons, Sometimes the template file may have some
- * pre-processing.For example, inserts some checking data in the form of
- * time reading the html file.
+ * Custom file loader. Useful for template preprocessing or restricting access
+ * to a certain part of the filesystem.
  *
- * @type {Function}
- * @public
+ * @type {fileLoader}
  */
 
 exports.fileLoader = fs.readFileSync;

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -984,6 +984,25 @@ suite('require', function () {
   });
 });
 
+suite('test fileloader', function () {
+
+  var myFileLoad = function (filePath) {
+    return 'myFileLoad: ' + fs.readFileSync(filePath);
+  };
+
+  test('test custom fileload', function (done) {
+    ejs.fileLoader = myFileLoad;
+    ejs.renderFile('test/fixtures/para.ejs', function(err, html) {
+      if (err) {
+        return done(err);
+      }
+      assert.equal(html, 'myFileLoad: <p>hey</p>\n');
+      done();
+    });
+
+  });
+});
+
 suite('examples', function () {
   function noop () {}
   fs.readdirSync('examples').forEach(function (f) {


### PR DESCRIPTION
For security reasons, Sometimes the template file may have some
pre-processing.For example, inserts some checking data in the form of
time reading the html file.

This amendment provides similar 'cache' to set custom fileloader.

``` js
ejs.fileLoader = MyFileLoader;
```

resolve mde/ejs#125
