### PR TITLE
Remove reference to non-existent api.md

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -42,8 +42,9 @@ Delimiters
 
 The *starting* and *closing* tags contain a special string called the
 delimiter. In this document, all tags are shown using the `%` delimiter, which
-is the default. You can, however, change that to your liking. See api.md for
-more information on how to change it.
+is the default. You can, however, change that to your liking. See 
+https://github.com/mde/ejs#custom-delimiters for more information on how to 
+change it.
 
 Starting tags
 -------------


### PR DESCRIPTION
As noted in #137, api.md does not exist. Now references the appropriate section of the README.

**This does not resolve issue #137.**