### PR TITLE
Added lookup function support 

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -118,7 +118,7 @@ function lookup(includePath,options){
   if (options&&typeof options.ejsLookup==='function'){
     return options.ejsLookup(includePath)||includePath;
   }
-  return includePath
+  return includePath;
 }
 /**
  * Get the template from a string or a file, either compiled on-the-fly or

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -99,10 +99,7 @@ exports.resolveInclude = function(name, filename,options) {
   if (!ext) {
     includePath += '.ejs';
   }
-  if (options){ 
-    return lookup(includePath,options);
-  }
-  return includePath;
+  return lookup(includePath,options);
 };
 
 /**
@@ -118,12 +115,10 @@ exports.resolveInclude = function(name, filename,options) {
  *                   
  */
 function lookup(includePath,options){
-  if (typeof options.ejsLookup!=='function'){
-    return includePath
-  }
-  else{
+  if (options&&typeof options.ejsLookup==='function'){
     return options.ejsLookup(includePath)||includePath;
   }
+  return includePath
 }
 /**
  * Get the template from a string or a file, either compiled on-the-fly or

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -415,7 +415,7 @@ function Template(text, opts) {
   options.cache = opts.cache || false;
   options.rmWhitespace = opts.rmWhitespace;
   options.localsName = opts.localsName || exports.localsName || _DEFAULT_LOCALS_NAME;
-  options.ejsLookup;
+  options.ejsLookup = opts.ejsLookup;
 
   if (options.strict) {
     options._with = false;

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -53,7 +53,7 @@ var fs = require('fs')
   , _REGEX_STRING = '(<%%|<%=|<%-|<%_|<%#|<%|%>|-%>|_%>)'
   , _OPTS = [ 'cache', 'filename', 'delimiter', 'scope', 'context'
             , 'debug', 'compileDebug', 'client', '_with', 'rmWhitespace'
-            , 'strict', 'localsName'
+            , 'strict', 'localsName', 'ejsLookup'
             ]
   , _TRAILING_SEMCOL = /;\s*$/
   , _BOM = /^\uFEFF/;
@@ -89,7 +89,7 @@ exports.localsName = _DEFAULT_LOCALS_NAME;
  * @return {String}
  */
 
-exports.resolveInclude = function(name, filename) {
+exports.resolveInclude = function(name, filename,options) {
   var path = require('path')
     , dirname = path.dirname
     , extname = path.extname
@@ -99,9 +99,32 @@ exports.resolveInclude = function(name, filename) {
   if (!ext) {
     includePath += '.ejs';
   }
+  if (options){ 
+    return lookup(includePath,options);
+  }
   return includePath;
 };
 
+/**
+ * Function that checks for the existence of lookup function
+ * in configuration and runs it if it's available
+ * This wrapper functon makes the existence of  a lookup function
+ * optional(if it's not provided the original resolved path is returned)
+ * 
+ * @param   {string}   includePath the original resolved path to be used 
+ *                                 to check for alternatives
+ * @param   {object}   options     compilation options
+ * @returns {string} the discovered path or the orginl one if none is found
+ *                   
+ */
+function lookup(includePath,options){
+  if (typeof options.ejsLookup!=='function'){
+    return includePath
+  }
+  else{
+    return options.ejsLookup(includePath)||includePath;
+  }
+}
 /**
  * Get the template from a string or a file, either compiled on-the-fly or
  * read from cache (if enabled), and cache the template if needed.
@@ -170,7 +193,7 @@ function includeFile(path, options) {
   if (!opts.filename) {
     throw new Error('`include` requires the \'filename\' option.');
   }
-  opts.filename = exports.resolveInclude(path, opts.filename);
+  opts.filename = exports.resolveInclude(path, opts.filename,opts);
   return handleCache(opts);
 }
 
@@ -191,7 +214,7 @@ function includeSource(path, options) {
   if (!opts.filename) {
     throw new Error('`include` requires the \'filename\' option.');
   }
-  includePath = exports.resolveInclude(path, opts.filename);
+  includePath = exports.resolveInclude(path, opts.filename, opts);
   template = fs.readFileSync(includePath).toString().replace(_BOM, '');
 
   opts.filename = includePath;

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -415,6 +415,7 @@ function Template(text, opts) {
   options.cache = opts.cache || false;
   options.rmWhitespace = opts.rmWhitespace;
   options.localsName = opts.localsName || exports.localsName || _DEFAULT_LOCALS_NAME;
+  options.ejsLookup;
 
   if (options.strict) {
     options._with = false;
@@ -578,7 +579,7 @@ Template.prototype = {
                 '    ; })()' + '\n';
             self.source += includeSrc;
             self.dependencies.push(exports.resolveInclude(include[1],
-                includeOpts.filename));
+                includeOpts.filename,self.opts));
             return;
           }
         }


### PR DESCRIPTION
app.locals.ejsLookup function that accepts the default resolved path and  returns whatever the developer wants giving him the opportunity to customise lookups .
This also solves https://github.com/mde/ejs/pull/120#
 since ejsLookup function can internally substitute view paths and replace them with the appropriate one
by creating a new express view and using its path from mynewview.path 
(this is not an express specific implementation  app.locals.ejsLookup can do anything from checking aliases to whatever the developer wants )