### PR TITLE
Add whitespace slurping tags to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,16 @@ the both the public & private API docs, run `npm run devdoc` instead.
 ## Tags
 
   - `<%`              'Scriptlet' tag, for control-flow, no output
+  - `<%_`             'Whitespace Slurping' Scriptlet tag, strips all whitespace before it
   - `<%=`             Outputs the value into the template (escaped)
   - `<%-`             Outputs the unescaped value into the template
   - `<%#`             Comment tag, no execution, no output
   - `<%%`             Outputs a literal '<%'
   - `%>`              Plain ending tag
   - `-%>`             Trim-mode ('newline slurp') tag, trims following newline
+  - `_%>`             'Whitespace Slurping' ending tag, removes all whitespace after it
+
+For the full syntax documentation, please see [docs/syntax.md](https://github.com/mde/ejs/blob/master/docs/syntax.md).
 
 ## Includes
 


### PR DESCRIPTION
No-conflict alternative to #159.

---

**Here is the original PR message:**

# Add whitespace slurping tags to README

They were listed under Features, but not under Tags.

I also added a link to syntax.md from the README.
