### PR TITLE
Fix include context

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -552,7 +552,7 @@ Template.prototype = {
             includeOpts = utils.shallowCopy({}, self.opts);
             includeSrc = includeSource(include[1], includeOpts);
             includeSrc = '    ; (function(){' + '\n' + includeSrc +
-                '    ; })()' + '\n';
+                '    ; }).call(this)' + '\n';
             self.source += includeSrc;
             self.dependencies.push(exports.resolveInclude(include[1],
                 includeOpts.filename));


### PR DESCRIPTION
To fix options.context is not applied to 'this' of sub template function when using 'include file.ejs'.