### PR TITLE
A better solution for PR 129

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -180,7 +180,7 @@ function includeFile(path, options) {
  * @memberof module:ejs-internal
  * @param {String}  path    path for the specified file
  * @param {Options} options compilation options
- * @return {String}
+ * @return {Object}
  * @static
  */
 
@@ -197,7 +197,11 @@ function includeSource(path, options) {
   opts.filename = includePath;
   var templ = new Template(template, opts);
   templ.generateSource();
-  return templ.source;
+  return {
+    source: templ.source,
+    filename: includePath,
+    template: template
+  };
 }
 
 /**
@@ -523,15 +527,12 @@ Template.prototype = {
       , d = this.opts.delimiter;
 
     if (matches && matches.length) {
-      if (this.opts.compileDebug && this.opts.filename) {
-        this.source =  '    ; __lines = ' + JSON.stringify(this.templateText) + '\n';
-        this.source += '    ; __filename = "' + this.opts.filename.replace(/\\/g,  '/') + '"\n';
-      }
       matches.forEach(function (line, index) {
         var opening
           , closing
           , include
           , includeOpts
+          , includeObj
           , includeSrc;
         // If this is an opening tag, check for closing tags
         // FIXME: May end up with some false positives here
@@ -550,9 +551,23 @@ Template.prototype = {
           // Must be in EVAL or RAW mode
           if (opening && (opening == '<' + d || opening == '<' + d + '-' || opening == '<' + d + '_')) {
             includeOpts = utils.shallowCopy({}, self.opts);
-            includeSrc = includeSource(include[1], includeOpts);
-            includeSrc = '    ; (function(){' + '\n' + includeSrc +
-                '    ; })()' + '\n';
+            includeObj = includeSource(include[1], includeOpts);
+            if (self.opts.compileDebug) {
+              includeSrc =
+                  '    ; (function(){' + '\n'
+                  + '      var __line = 1' + '\n'
+                  + '      , __lines = ' + JSON.stringify(includeObj.template) + '\n'
+                  + '      , __filename = ' + JSON.stringify(includeObj.filename) + ';' + '\n'
+                  + '      try {' + '\n'
+                  + includeObj.source
+                  + '      } catch (e) {' + '\n'
+                  + '        rethrow(e, __lines, __filename, __line);' + '\n'
+                  + '      }' + '\n'
+                  + '    ; }).call(this)' + '\n';
+            }else{
+              includeSrc = '    ; (function(){' + '\n' + includeObj.source +
+                  '    ; }).call(this)' + '\n';
+            }
             self.source += includeSrc;
             self.dependencies.push(exports.resolveInclude(include[1],
                 includeOpts.filename));


### PR DESCRIPTION
The [PR 129](https://github.com/mde/ejs/pull/129) fixed issue 119, but would lost the include line's error information(such as his sample, we can't get error 'ejs/sample/index.html:18'). On the other way, his solution would make error filename wrong when you use both <%include('header.html')%> and <%-include body.html%>.

So I think this solution makes things better. After using this PR, as his sample, the error information displays as bellow.

```
ReferenceError: /Users/Spikef/ejs/sample/index.html:18
   16| this_variable_is_not_defined is not defined
   17| -->
>> 18| <% include body.html %>
   19| </body>
   20| </html>

/Users/Spikef/ejs/sample/body.html:2
   1| <!-- Execute an exception -->
>> 2| <p><%= this_variable_is_not_defined %></p>
```