### PR TITLE
Highlight inline code

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm install ejs
   * Unescaped raw output with `<%- %>`
   * Newline-trim mode ('newline slurping') with `-%>` ending tag
   * Whitespace-trim mode (slurp all whitespace) for control flow with `<%_ _%>`
-  * Custom delimiters (e.g., use '<? ?>' instead of '<% %>')
+  * Custom delimiters (e.g., use `<? ?>` instead of `<% %>`)
   * Includes
   * Client-side support
   * Static caching of intermediate JavaScript


### PR DESCRIPTION
I'm not sure if there was a specific reason to use `'` instead of ``` ` ``` there, but I guess it looks better like this. 😁 