### PR TITLE
Add tests for strict mode

### DIFF
--- a/test/ejs.js
+++ b/test/ejs.js
@@ -161,6 +161,11 @@ suite('ejs.compile(str, options)', function () {
     }
   });
 
+  test('strict mode works', function () {
+    var fn = ejs.compile('Hello <%= name %>!', {strict: true, client: true});
+    assert.notEqual(fn.toString().indexOf('"use strict";'), -1);
+  });
+
 });
 
 suite('ejs.render(str, data, opts)', function () {
@@ -900,7 +905,7 @@ suite('preprocessor include', function () {
     out = ejs.render(fixture('include_preprocessor_cache.ejs'), {}, options);
     assert.equal(out, expected);
   });
-  
+
   test('whitespace slurp and rmWhitespace work', function() {
     var file = 'test/fixtures/include_preprocessor_line_slurp.ejs'
       , template = fixture('include_preprocessor_line_slurp.ejs')
@@ -909,7 +914,7 @@ suite('preprocessor include', function () {
     assert.equal(ejs.render(template, options),
         expected);
   })
-  
+
 });
 
 suite('comments', function () {


### PR DESCRIPTION
@TimothyGu I don't know if this is too hacky, but this is the only way I can think how to test it. If it looks good to you, please merge this.

My text editor trimmed some trailing whitespace as well.

## Coverage Report

**Before:**
```
=============================== Coverage summary ===============================
Statements   : 95.17% ( 276/290 ), 3 ignored
Branches     : 88.65% ( 164/185 ), 6 ignored
Functions    : 100% ( 32/32 )
Lines        : 95.17% ( 276/290 )
================================================================================
```
**After:**
```
=============================== Coverage summary ===============================
Statements   : 95.86% ( 278/290 ), 3 ignored
Branches     : 89.73% ( 166/185 ), 6 ignored
Functions    : 100% ( 32/32 )
Lines        : 95.86% ( 278/290 )
================================================================================
```