### PR TITLE
Add link to ejs-playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ $ npm install ejs
 <% } %>
 ```
 
+Try EJS online at: https://ionicabizau.github.io/ejs-playground/.
+
 ## Usage
 
 ```javascript


### PR DESCRIPTION
@IonicaBizau did a great job of building an online EJS playground, and I think it would be nice to link to it from the README.

Try it here: https://ionicabizau.github.io/ejs-playground/. The repo is: https://github.com/IonicaBizau/ejs-playground

CC: @mde @TimothyGu 