### PR TITLE
Auto-deploy JSDocs to gh-pages after jake publish

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -31,6 +31,19 @@ task('minify', function () {
   console.log('Minification completed.');
 });
 
+task('doc', function (dev) {
+  jake.rmRf('out');
+  var p = dev ? '-p' : '';
+  exec('./node_modules/.bin/jsdoc ' + p + ' -c jsdoc.json lib/* docs/jsdoc/*');
+  console.log('Documentation generated.');
+})
+
+task('docPublish', ['doc'], function () {
+  console.log('Pushing docs to gh-pages...');
+  exec('./node_modules/.bin/git-directory-deploy --directory out/');
+  console.log('Docs published to gh-pages.');
+});
+
 publishTask('ejs', ['build'], function () {
   this.packageFiles.include([
     'Jakefile',
@@ -42,4 +55,10 @@ publishTask('ejs', ['build'], function () {
     'lib/**',
     'test/**'
   ]);
+});
+
+jake.Task.publish.on('complete', function () {
+  console.log('Updating hosted docs...');
+  console.log('If this fails, run jake docPublish to re-try.');
+  jake.Task.docPublish.invoke();
 });

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   "devDependencies": {
     "browserify": "^13.0.1",
     "eslint": "^3.0.0",
+    "git-directory-deploy": "^1.5.1",
     "istanbul": "~0.4.3",
     "jake": "^8.0.0",
     "jsdoc": "^3.4.0",
     "lru-cache": "^4.0.1",
     "mocha": "3.0.2",
-    "rimraf": "^2.2.8",
     "uglify-js": "^2.6.2"
   },
   "engines": {
@@ -38,7 +38,7 @@
     "test": "mocha",
     "lint": "eslint \"**/*.js\" Jakefile",
     "coverage": "istanbul cover node_modules/mocha/bin/_mocha",
-    "doc": "rimraf out && jsdoc -c jsdoc.json lib/* docs/jsdoc/*",
-    "devdoc": "rimraf out && jsdoc -p -c jsdoc.json lib/* docs/jsdoc/*"
+    "doc": "jake doc",
+    "devdoc": "jake doc[dev]"
   }
 }


### PR DESCRIPTION
Use git-directory-deploy.

This is my attempt at https://github.com/mde/ejs/issues/137.

@mde @TimothyGu Review?