### PR TITLE
Fix .eslintignore and lint errors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
 coverage
 out
-ejs.js
-ejs.min.js
+/ejs.js
+/ejs.min.js

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -665,77 +665,77 @@ Template.prototype = {
     newLineCount = (line.split('\n').length - 1);
 
     switch (line) {
-      case '<' + d:
-      case '<' + d + '_':
-        this.mode = Template.modes.EVAL;
-        break;
-      case '<' + d + '=':
-        this.mode = Template.modes.ESCAPED;
-        break;
-      case '<' + d + '-':
-        this.mode = Template.modes.RAW;
-        break;
-      case '<' + d + '#':
-        this.mode = Template.modes.COMMENT;
-        break;
-      case '<' + d + d:
-        this.mode = Template.modes.LITERAL;
-        this.source += '    ; __append("' + line.replace('<' + d + d, '<' + d) + '")' + '\n';
-        break;
-      case d + d + '>':
-        this.mode = Template.modes.LITERAL;
-        this.source += '    ; __append("' + line.replace(d + d + '>', d + '>') + '")' + '\n';
-        break;
-      case d + '>':
-      case '-' + d + '>':
-      case '_' + d + '>':
-        if (this.mode == Template.modes.LITERAL) {
-          _addOutput();
-        }
+    case '<' + d:
+    case '<' + d + '_':
+      this.mode = Template.modes.EVAL;
+      break;
+    case '<' + d + '=':
+      this.mode = Template.modes.ESCAPED;
+      break;
+    case '<' + d + '-':
+      this.mode = Template.modes.RAW;
+      break;
+    case '<' + d + '#':
+      this.mode = Template.modes.COMMENT;
+      break;
+    case '<' + d + d:
+      this.mode = Template.modes.LITERAL;
+      this.source += '    ; __append("' + line.replace('<' + d + d, '<' + d) + '")' + '\n';
+      break;
+    case d + d + '>':
+      this.mode = Template.modes.LITERAL;
+      this.source += '    ; __append("' + line.replace(d + d + '>', d + '>') + '")' + '\n';
+      break;
+    case d + '>':
+    case '-' + d + '>':
+    case '_' + d + '>':
+      if (this.mode == Template.modes.LITERAL) {
+        _addOutput();
+      }
 
-        this.mode = null;
-        this.truncate = line.indexOf('-') === 0 || line.indexOf('_') === 0;
-        break;
-      default:
+      this.mode = null;
+      this.truncate = line.indexOf('-') === 0 || line.indexOf('_') === 0;
+      break;
+    default:
         // In script mode, depends on type of tag
-        if (this.mode) {
+      if (this.mode) {
           // If '//' is found without a line break, add a line break.
-          switch (this.mode) {
-            case Template.modes.EVAL:
-            case Template.modes.ESCAPED:
-            case Template.modes.RAW:
-              if (line.lastIndexOf('//') > line.lastIndexOf('\n')) {
-                line += '\n';
-              }
+        switch (this.mode) {
+        case Template.modes.EVAL:
+        case Template.modes.ESCAPED:
+        case Template.modes.RAW:
+          if (line.lastIndexOf('//') > line.lastIndexOf('\n')) {
+            line += '\n';
           }
-          switch (this.mode) {
+        }
+        switch (this.mode) {
             // Just executing code
-            case Template.modes.EVAL:
-              this.source += '    ; ' + line + '\n';
-              break;
+        case Template.modes.EVAL:
+          this.source += '    ; ' + line + '\n';
+          break;
             // Exec, esc, and output
-            case Template.modes.ESCAPED:
-              this.source += '    ; __append(escape(' +
+        case Template.modes.ESCAPED:
+          this.source += '    ; __append(escape(' +
                 line.replace(_TRAILING_SEMCOL, '').trim() + '))' + '\n';
-              break;
+          break;
             // Exec and output
-            case Template.modes.RAW:
-              this.source += '    ; __append(' +
+        case Template.modes.RAW:
+          this.source += '    ; __append(' +
                 line.replace(_TRAILING_SEMCOL, '').trim() + ')' + '\n';
-              break;
-            case Template.modes.COMMENT:
+          break;
+        case Template.modes.COMMENT:
               // Do nothing
-              break;
+          break;
             // Literal <%% mode, append as raw output
-            case Template.modes.LITERAL:
-              _addOutput();
-              break;
-          }
-        }
-        // In string mode, just add the output
-        else {
+        case Template.modes.LITERAL:
           _addOutput();
+          break;
         }
+      }
+        // In string mode, just add the output
+      else {
+        _addOutput();
+      }
     }
 
     if (self.opts.compileDebug && newLineCount) {
@@ -776,9 +776,9 @@ if (require.extensions) {
   require.extensions['.ejs'] = function (module, flnm) {
     var filename = flnm || /* istanbul ignore next */ module.filename;
     var options = {
-          filename: filename,
-          client: true
-        };
+      filename: filename,
+      client: true
+    };
     var template = fs.readFileSync(filename).toString();
     var fn = exports.compile(template, options);
     module._compile('module.exports = ' + fn.toString() + ';', filename);

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -1,15 +1,16 @@
 /* jshint mocha: true */
+/* eslint-env node, mocha */
 
 /**
  * Module dependencies.
  */
 
-var ejs = require('..')
-  , fs = require('fs')
-  , read = fs.readFileSync
-  , assert = require('assert')
-  , path = require('path')
-  , LRU = require('lru-cache');
+var ejs = require('..');
+var fs = require('fs');
+var read = fs.readFileSync;
+var assert = require('assert');
+var path = require('path');
+var LRU = require('lru-cache');
 
 try {
   fs.mkdirSync(__dirname + '/tmp');
@@ -104,9 +105,9 @@ suite('ejs.compile(str, options)', function () {
   });
 
   test('have a working client option', function () {
-    var fn
-      , str
-      , preFn;
+    var fn;
+    var str;
+    var preFn;
     fn = ejs.compile('<p><%= foo %></p>', {client: true});
     str = fn.toString();
     if (!process.env.running_under_istanbul) {
@@ -116,9 +117,9 @@ suite('ejs.compile(str, options)', function () {
   });
 
   test('support client mode without locals', function () {
-    var fn
-      , str
-      , preFn;
+    var fn;
+    var str;
+    var preFn;
     fn = ejs.compile('<p><%= "foo" %></p>', {client: true});
     str = fn.toString();
     if (!process.env.running_under_istanbul) {
@@ -129,16 +130,16 @@ suite('ejs.compile(str, options)', function () {
 
   test('not include rethrow() in client mode if compileDebug is false', function () {
     var fn = ejs.compile('<p><%= "foo" %></p>', {
-               client: true
-             , compileDebug: false
-             });
+      client: true,
+      compileDebug: false
+    });
     // There could be a `rethrow` in the function declaration
     assert((fn.toString().match(/rethrow/g) || []).length <= 1);
   });
 
   test('support custom escape function', function () {
-    var customEscape
-      , fn;
+    var customEscape;
+    var fn;
     customEscape = function customEscape(str) {
       return !str ? '' : str.toUpperCase();
     };
@@ -147,9 +148,9 @@ suite('ejs.compile(str, options)', function () {
   });
 
   test('support custom escape function in client mode', function () {
-    var customEscape
-      , fn
-      , str;
+    var customEscape;
+    var fn;
+    var str;
     customEscape = function customEscape(str) {
       return !str ? '' : str.toUpperCase();
     };
@@ -157,7 +158,7 @@ suite('ejs.compile(str, options)', function () {
     str = fn.toString();
     if (!process.env.running_under_istanbul) {
       eval('var preFn = ' + str);
-      assert.equal(preFn({name: 'world'}), 'HELLO WORLD');
+      assert.equal(preFn({name: 'world'}), 'HELLO WORLD'); // eslint-disable-line no-undef
     }
   });
 
@@ -228,10 +229,10 @@ suite('ejs.render(str, data, opts)', function () {
   });
 
   test('support caching', function () {
-    var file = __dirname + '/tmp/render.ejs'
-      , options = {cache: true, filename: file}
-      , out = ejs.render('<p>Old</p>', {}, options)
-      , expected = '<p>Old</p>';
+    var file = __dirname + '/tmp/render.ejs';
+    var options = {cache: true, filename: file};
+    var out = ejs.render('<p>Old</p>', {}, options);
+    var expected = '<p>Old</p>';
     assert.equal(out, expected);
     // Assert no change, still in cache
     out = ejs.render('<p>New</p>', {}, options);
@@ -239,11 +240,11 @@ suite('ejs.render(str, data, opts)', function () {
   });
 
   test('support LRU caching', function () {
-    var oldCache = ejs.cache
-      , file = __dirname + '/tmp/render.ejs'
-      , options = {cache: true, filename: file}
-      , out
-      , expected = '<p>Old</p>';
+    var oldCache = ejs.cache;
+    var file = __dirname + '/tmp/render.ejs';
+    var options = {cache: true, filename: file};
+    var out;
+    var expected = '<p>Old</p>';
 
     // Switch to LRU
     ejs.cache = LRU();
@@ -259,8 +260,8 @@ suite('ejs.render(str, data, opts)', function () {
   });
 
   test('opts.context', function () {
-    var ctxt = {foo: 'FOO'}
-      , out = ejs.render('<%= this.foo %>', {}, {context: ctxt});
+    var ctxt = {foo: 'FOO'};
+    var out = ejs.render('<%= this.foo %>', {}, {context: ctxt});
     assert.equal(out, ctxt.foo);
   });
 });
@@ -277,8 +278,8 @@ suite('ejs.renderFile(path, [data], [options], fn)', function () {
   });
 
   test('accept locals', function(done) {
-    var data =  {name: 'fonebone'}
-      , options = {delimiter: '$'};
+    var data =  {name: 'fonebone'};
+    var options = {delimiter: '$'};
     ejs.renderFile('test/fixtures/user.ejs', data, options, function(err, html) {
       if (err) {
         return done(err);
@@ -289,11 +290,10 @@ suite('ejs.renderFile(path, [data], [options], fn)', function () {
   });
 
   test('accept locals without using with() {}', function(done) {
-    var data =  {name: 'fonebone'}
-      , options = {delimiter: '$', _with: false}
-      , doneCount = 0;
-    ejs.renderFile('test/fixtures/user-no-with.ejs', data, options,
-                   function(err, html) {
+    var data =  {name: 'fonebone'};
+    var options = {delimiter: '$', _with: false};
+    var doneCount = 0;
+    ejs.renderFile('test/fixtures/user-no-with.ejs', data, options, function(err, html) {
       if (err) {
         if (doneCount === 2) {
           return;
@@ -323,9 +323,9 @@ suite('ejs.renderFile(path, [data], [options], fn)', function () {
   });
 
   test('not catch err thrown by callback', function(done) {
-    var data =  {name: 'fonebone'}
-      , options = {delimiter: '$'}
-      , counter = 0;
+    var data =  {name: 'fonebone'};
+    var options = {delimiter: '$'};
+    var counter = 0;
 
     var d = require('domain').create();
     d.on('error', function (err) {
@@ -340,8 +340,7 @@ suite('ejs.renderFile(path, [data], [options], fn)', function () {
       // domains. Have to make it async. Ticket closed because: "domains are
       // deprecated :D"
       process.nextTick(function () {
-        ejs.renderFile('test/fixtures/user.ejs', data, options,
-                       function(err) {
+        ejs.renderFile('test/fixtures/user.ejs', data, options, function(err) {
           counter++;
           if (err) {
             assert.notEqual(err.message, 'Exception in callback');
@@ -354,9 +353,9 @@ suite('ejs.renderFile(path, [data], [options], fn)', function () {
   });
 
   test('support caching', function (done) {
-    var expected = '<p>Old</p>'
-      , file = __dirname + '/tmp/renderFile.ejs'
-      , options = {cache: true};
+    var expected = '<p>Old</p>';
+    var file = __dirname + '/tmp/renderFile.ejs';
+    var options = {cache: true};
     fs.writeFileSync(file, '<p>Old</p>');
 
     ejs.renderFile(file, {}, options, function (err, out) {
@@ -379,8 +378,7 @@ suite('ejs.renderFile(path, [data], [options], fn)', function () {
 
   test('opts.context', function (done) {
     var ctxt = {foo: 'FOO'};
-    ejs.renderFile('test/fixtures/with-context.ejs', {},
-          {context: ctxt}, function(err, html) {
+    ejs.renderFile('test/fixtures/with-context.ejs', {}, {context: ctxt}, function(err, html) {
       if (err) {
         return done(err);
       }
@@ -393,10 +391,10 @@ suite('ejs.renderFile(path, [data], [options], fn)', function () {
 
 suite('cache specific', function () {
   test('`clearCache` work properly', function () {
-    var expected = '<p>Old</p>'
-      , file = __dirname + '/tmp/clearCache.ejs'
-      , options = {cache: true, filename: file}
-      , out = ejs.render('<p>Old</p>', {}, options);
+    var expected = '<p>Old</p>';
+    var file = __dirname + '/tmp/clearCache.ejs';
+    var options = {cache: true, filename: file};
+    var out = ejs.render('<p>Old</p>', {}, options);
     assert.equal(out, expected);
 
     ejs.clearCache();
@@ -407,11 +405,11 @@ suite('cache specific', function () {
   });
 
   test('`clearCache` work properly, LRU', function () {
-    var expected = '<p>Old</p>'
-      , oldCache = ejs.cache
-      , file = __dirname + '/tmp/clearCache.ejs'
-      , options = {cache: true, filename: file}
-      , out;
+    var expected = '<p>Old</p>';
+    var oldCache = ejs.cache;
+    var file = __dirname + '/tmp/clearCache.ejs';
+    var options = {cache: true, filename: file};
+    var out;
 
     ejs.cache = LRU();
 
@@ -426,11 +424,11 @@ suite('cache specific', function () {
   });
 
   test('LRU with cache-size 1', function () {
-    var oldCache = ejs.cache
-      , options
-      , out
-      , expected
-      , file;
+    var oldCache = ejs.cache;
+    var options;
+    var out;
+    var expected;
+    var file;
 
     ejs.cache = LRU(1);
 
@@ -555,13 +553,13 @@ suite('-%>', function () {
   });
 
   test('works with unix style', function () {
-    var content = "<ul><% -%>\n"
-    + "<% users.forEach(function(user){ -%>\n"
-    + "<li><%= user.name -%></li>\n"
-    + "<% }) -%>\n"
-    + "</ul><% -%>\n";
+    var content = '<ul><% -%>\n'
+    + '<% users.forEach(function(user){ -%>\n'
+    + '<li><%= user.name -%></li>\n'
+    + '<% }) -%>\n'
+    + '</ul><% -%>\n';
 
-    var expectedResult = "<ul><li>geddy</li>\n<li>neil</li>\n<li>alex</li>\n</ul>";
+    var expectedResult = '<ul><li>geddy</li>\n<li>neil</li>\n<li>alex</li>\n</ul>';
     var fn;
     fn = ejs.compile(content);
     assert.equal(fn({users: users}),
@@ -569,13 +567,13 @@ suite('-%>', function () {
   });
 
   test('works with windows style', function () {
-    var content = "<ul><% -%>\r\n"
-    + "<% users.forEach(function(user){ -%>\r\n"
-    + "<li><%= user.name -%></li>\r\n"
-    + "<% }) -%>\r\n"
-    + "</ul><% -%>\r\n";
+    var content = '<ul><% -%>\r\n'
+    + '<% users.forEach(function(user){ -%>\r\n'
+    + '<li><%= user.name -%></li>\r\n'
+    + '<% }) -%>\r\n'
+    + '</ul><% -%>\r\n';
 
-    var expectedResult = "<ul><li>geddy</li>\r\n<li>neil</li>\r\n<li>alex</li>\r\n</ul>";
+    var expectedResult = '<ul><li>geddy</li>\r\n<li>neil</li>\r\n<li>alex</li>\r\n</ul>';
     var fn;
     fn = ejs.compile(content);
     assert.equal(fn({users: users}),
@@ -669,8 +667,8 @@ suite('exceptions', function () {
 
   var unhook = null;
   test('log JS source when debug is set', function (done) {
-    var out = ''
-      , needToExit = false;
+    var out = '';
+    var needToExit = false;
     unhook = hook_stdio(process.stdout, function (str) {
       out += str;
       if (needToExit) {
@@ -741,8 +739,8 @@ suite('include()', function () {
   });
 
   test('include ejs with set root path', function () {
-    var file = 'test/fixtures/include-root.ejs',
-        viewsPath = path.join(__dirname, 'fixtures');
+    var file = 'test/fixtures/include-root.ejs';
+    var viewsPath = path.join(__dirname, 'fixtures');
     assert.equal(ejs.render(fixture('include-root.ejs'), {pets: users}, {filename: file, delimiter: '@',root:viewsPath}),
       fixture('include.html'));
 
@@ -755,8 +753,8 @@ suite('include()', function () {
   });
 
   test('work with a variable path', function () {
-    var file = 'test/fixtures/menu_var.ejs',
-        includePath = 'includes/menu-item';
+    var file = 'test/fixtures/menu_var.ejs';
+    var includePath = 'includes/menu-item';
     assert.equal(ejs.render(fixture('menu.ejs'), {pets: users, varPath:  includePath}, {filename: file}),
       fixture('menu.html'));
   });
@@ -768,12 +766,12 @@ suite('include()', function () {
   });
 
   test('pass compileDebug to include', function () {
-    var file = 'test/fixtures/include.ejs'
-      , fn;
+    var file = 'test/fixtures/include.ejs';
+    var fn;
     fn = ejs.compile(fixture('include.ejs'), {
-      filename: file
-    , delimiter: '@'
-    , compileDebug: false
+      filename: file,
+      delimiter: '@',
+      compileDebug: false
     });
     try {
       // Render without a required variable reference
@@ -789,9 +787,9 @@ suite('include()', function () {
 
   test('is dynamic', function () {
     fs.writeFileSync(__dirname + '/tmp/include.ejs', '<p>Old</p>');
-    var file = 'test/fixtures/include_cache.ejs'
-      , options = {filename: file}
-      , out = ejs.compile(fixture('include_cache.ejs'), options);
+    var file = 'test/fixtures/include_cache.ejs';
+    var options = {filename: file};
+    var out = ejs.compile(fixture('include_cache.ejs'), options);
     assert.equal(out(), '<p>Old</p>\n');
 
     fs.writeFileSync(__dirname + '/tmp/include.ejs', '<p>New</p>');
@@ -800,10 +798,10 @@ suite('include()', function () {
 
   test('support caching', function () {
     fs.writeFileSync(__dirname + '/tmp/include.ejs', '<p>Old</p>');
-    var file = 'test/fixtures/include_cache.ejs'
-      , options = {cache: true, filename: file}
-      , out = ejs.render(fixture('include_cache.ejs'), {}, options)
-      , expected = fixture('include_cache.html');
+    var file = 'test/fixtures/include_cache.ejs';
+    var options = {cache: true, filename: file};
+    var out = ejs.render(fixture('include_cache.ejs'), {}, options);
+    var expected = fixture('include_cache.html');
     assert.equal(out, expected);
     out = ejs.render(fixture('include_cache.ejs'), {}, options);
     // No change, still in cache
@@ -851,8 +849,8 @@ suite('preprocessor include', function () {
   });
 
   test('tracks dependency correctly', function () {
-    var file = 'test/fixtures/menu_preprocessor.ejs'
-      , fn = ejs.compile(fixture('menu_preprocessor.ejs'), {filename: file});
+    var file = 'test/fixtures/menu_preprocessor.ejs';
+    var fn = ejs.compile(fixture('menu_preprocessor.ejs'), {filename: file});
     assert(fn.dependencies.length);
   });
 
@@ -863,12 +861,12 @@ suite('preprocessor include', function () {
   });
 
   test('pass compileDebug to include', function () {
-    var file = 'test/fixtures/include_preprocessor.ejs'
-      , fn;
+    var file = 'test/fixtures/include_preprocessor.ejs';
+    var fn;
     fn = ejs.compile(fixture('include_preprocessor.ejs'), {
-      filename: file
-    , delimiter: '@'
-    , compileDebug: false
+      filename: file,
+      delimiter: '@',
+      compileDebug: false
     });
     try {
       // Render without a required variable reference
@@ -884,9 +882,9 @@ suite('preprocessor include', function () {
 
   test('is static', function () {
     fs.writeFileSync(__dirname + '/tmp/include_preprocessor.ejs', '<p>Old</p>');
-    var file = 'test/fixtures/include_preprocessor_cache.ejs'
-      , options = {filename: file}
-      , out = ejs.compile(fixture('include_preprocessor_cache.ejs'), options);
+    var file = 'test/fixtures/include_preprocessor_cache.ejs';
+    var options = {filename: file};
+    var out = ejs.compile(fixture('include_preprocessor_cache.ejs'), options);
     assert.equal(out(), '<p>Old</p>\n');
 
     fs.writeFileSync(__dirname + '/tmp/include_preprocessor.ejs', '<p>New</p>');
@@ -895,10 +893,10 @@ suite('preprocessor include', function () {
 
   test('support caching', function () {
     fs.writeFileSync(__dirname + '/tmp/include_preprocessor.ejs', '<p>Old</p>');
-    var file = 'test/fixtures/include_preprocessor_cache.ejs'
-      , options = {cache: true, filename: file}
-      , out = ejs.render(fixture('include_preprocessor_cache.ejs'), {}, options)
-      , expected = fixture('include_preprocessor_cache.html');
+    var file = 'test/fixtures/include_preprocessor_cache.ejs';
+    var options = {cache: true, filename: file};
+    var out = ejs.render(fixture('include_preprocessor_cache.ejs'), {}, options);
+    var expected = fixture('include_preprocessor_cache.html');
     assert.equal(out, expected);
     fs.writeFileSync(__dirname + '/tmp/include_preprocessor.ejs', '<p>New</p>');
     out = ejs.render(fixture('include_preprocessor_cache.ejs'), {}, options);
@@ -906,13 +904,13 @@ suite('preprocessor include', function () {
   });
 
   test('whitespace slurp and rmWhitespace work', function() {
-    var file = 'test/fixtures/include_preprocessor_line_slurp.ejs'
-      , template = fixture('include_preprocessor_line_slurp.ejs')
-      , expected = fixture('include_preprocessor_line_slurp.html')
-      , options = {rmWhitespace: true, filename: file};
+    var file = 'test/fixtures/include_preprocessor_line_slurp.ejs';
+    var template = fixture('include_preprocessor_line_slurp.ejs');
+    var expected = fixture('include_preprocessor_line_slurp.html');
+    var options = {rmWhitespace: true, filename: file};
     assert.equal(ejs.render(template, options),
         expected);
-  })
+  });
 
 });
 
@@ -927,12 +925,12 @@ suite('require', function () {
 
   // Only works with inline/preprocessor includes
   test('allow ejs templates to be required as node modules', function () {
-      var file = 'test/fixtures/include_preprocessor.ejs'
-        , template = require(__dirname + '/fixtures/menu_preprocessor.ejs');
-      if (!process.env.running_under_istanbul) {
-        assert.equal(template({filename: file, pets: users}),
+    var file = 'test/fixtures/include_preprocessor.ejs';
+    var template = require(__dirname + '/fixtures/menu_preprocessor.ejs');
+    if (!process.env.running_under_istanbul) {
+      assert.equal(template({filename: file, pets: users}),
           fixture('menu_preprocessor.html'));
-      }
+    }
   });
 });
 
@@ -944,8 +942,8 @@ suite('examples', function () {
     }
     suite(f, function () {
       test('doesn\'t throw any errors', function () {
-        var stderr = hook_stdio(process.stderr, noop)
-          , stdout = hook_stdio(process.stdout, noop);
+        var stderr = hook_stdio(process.stderr, noop);
+        var stdout = hook_stdio(process.stdout, noop);
         try {
           require('../examples/' + f);
         }


### PR DESCRIPTION
The .eslintignore was misconfigured. In an attempt not to validate the browserified bundles, we added `ejs.js` to the .eslintignore. This not only ignored the bundle, it also ignored `lib/ejs.js` & `test/ejs.js`. This line was corrected to read `/ejs.js`.

As a result of this, quite a few linting errors needed fixed.

I will merge this in a few days if there are no corrections.