### PR TITLE
Fix global variable leak in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jake": "^8.0.0",
     "jsdoc": "^3.4.0",
     "lru-cache": "^4.0.1",
-    "mocha": "3.0.2",
+    "mocha": "^3.0.2",
     "uglify-js": "^2.6.2"
   },
   "engines": {

--- a/test/fixtures/no.newlines.error.ejs
+++ b/test/fixtures/no.newlines.error.ejs
@@ -1,5 +1,5 @@
 AAA
-<% data = "test"; -%>
+<% var data = "test"; -%>
 BBB
 <%= qdata %>
 CCC


### PR DESCRIPTION
This was causing tests to fail in mocha v3.1.0. Since this is fixed we are unpinning the mocha version.

Reverts e36b7595edd6a54f2b3f8b4fa5e8ee199c0564e9.

Fixes #206.