### PR TITLE
Adds a name attribute for easy identification

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -52,6 +52,7 @@ var scopeOptionWarned = false;
 var _VERSION_STRING = require('../package.json').version;
 var _DEFAULT_DELIMITER = '%';
 var _DEFAULT_LOCALS_NAME = 'locals';
+var _NAME = 'ejs';
 var _REGEX_STRING = '(<%%|%%>|<%=|<%-|<%_|<%#|<%|%>|-%>|_%>)';
 var _OPTS = [ 'cache', 'filename', 'delimiter', 'scope', 'context',
         'debug', 'compileDebug', 'client', '_with', 'root', 'rmWhitespace',
@@ -805,6 +806,16 @@ if (require.extensions) {
  */
 
 exports.VERSION = _VERSION_STRING;
+
+/**
+ * Name for detection of EJS.
+ *
+ * @readonly
+ * @type {String}
+ * @public
+ */
+
+exports.name = _NAME;
 
 /* istanbul ignore if */
 if (typeof window != 'undefined') {

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -982,3 +982,13 @@ suite('examples', function () {
     });
   });
 });
+
+suite('meta information', function () {
+  test('has a version', function () {
+    assert.strictEqual(ejs.VERSION, require('../package.json').version);
+  });
+
+  test('had a name', function () {
+    assert.strictEqual(ejs.name, 'ejs');
+  });
+});


### PR DESCRIPTION
Since there is not a constructor and thus a constructor.name
for detection this provides a name that can be used for the same
purpose. This is useful for application servers that allow the
template engine to be passed in.

I am working on PRs for other template engines for this as well.
It should also be noted that Handlebars, lodash, and underscore
are all detectable through this method already.

doT: https://github.com/olado/doT/pull/216
Jade/Pug: https://github.com/pugjs/pug/pull/2630