### PR TITLE
Improve performance of the renderFile() function by up to 4x

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -56,6 +56,10 @@ var _NAME = 'ejs';
 var _REGEX_STRING = '(<%%|%%>|<%=|<%-|<%_|<%#|<%|%>|-%>|_%>)';
 var _OPTS = ['delimiter', 'scope', 'context', 'debug', 'compileDebug',
   'client', '_with', 'rmWhitespace', 'strict', 'filename'];
+// We don't allow 'cache' option to be passed in the data obj
+// for the normal `render` call, but this is where Express puts it
+// so we make an exception for `renderFile`
+var _OPTS_EXPRESS = _OPTS.concat('cache');
 var _BOM = /^\uFEFF/;
 
 /**
@@ -170,6 +174,29 @@ function handleCache(options, template) {
     exports.cache.set(filename, func);
   }
   return func;
+}
+
+/**
+ * Try calling handleCache with the given options and data and call the
+ * callback with the result. If an error occurs, call the callback with
+ * the error. Used by renderFile().
+ *
+ * @memberof module:ejs-internal
+ * @param {Options} options    compilation options
+ * @param {Object} data        template data
+ * @param {RenderFileCallback} cb callback
+ * @static
+ */
+
+function tryHandleCache(options, data, cb) {
+  var result;
+  try {
+    result = handleCache(options)(data);
+  }
+  catch (err) {
+    return cb(err);
+  }
+  return cb(null, result);
 }
 
 /**
@@ -330,43 +357,38 @@ exports.render = function (template, d, o) {
  */
 
 exports.renderFile = function () {
-  var args = Array.prototype.slice.call(arguments);
-  var filename = args.shift();
-  var cb = args.pop();
-  var data = args.shift() || {};
-  var opts = args.pop() || {};
-  var optsKeys =_OPTS.slice();
-  var result;
+  var filename = arguments[0];
+  var cb = arguments[arguments.length - 1];
+  var opts = {filename: filename};
+  var data;
 
-  // Don't pollute passed in opts obj with new vals
-  opts = utils.shallowCopy({}, opts);
+  if (arguments.length > 2) {
+    data = arguments[1];
 
-  // We don't allow 'cache' option to be passed in the data obj
-  // for the normal `render` call, but this is where Expres puts it
-  // so we make an exception for `renderFile`
-  optsKeys.push('cache');
-
-  // No options object -- if there are optiony names
-  // in the data, copy them to options
-  if (arguments.length == 3) {
-    // Express 4
-    if (data.settings && data.settings['view options']) {
-      utils.shallowCopyFromList(opts, data.settings['view options'], optsKeys);
+    // No options object -- if there are optiony names
+    // in the data, copy them to options
+    if (arguments.length === 3) {
+      // Express 4
+      if (data.settings && data.settings['view options']) {
+        utils.shallowCopyFromList(opts, data.settings['view options'], _OPTS_EXPRESS);
+      }
+      // Express 3 and lower
+      else {
+        utils.shallowCopyFromList(opts, data, _OPTS_EXPRESS);
+      }
     }
-    // Express 3 and lower
     else {
-      utils.shallowCopyFromList(opts, data, optsKeys);
+      // Use shallowCopy so we don't pollute passed in opts obj with new vals
+      utils.shallowCopy(opts, arguments[2]);
     }
-  }
-  opts.filename = filename;
 
-  try {
-    result = handleCache(opts)(data);
+    opts.filename = filename;
   }
-  catch(err) {
-    return cb(err);
+  else {
+    data = {};
   }
-  return cb(null, result);
+
+  return tryHandleCache(opts, data, cb);
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -133,11 +133,12 @@ exports.shallowCopy = function (to, from) {
  * @private
  */
 exports.shallowCopyFromList = function (to, from, list) {
-  list.forEach(function (p) {
+  for (var i = 0; i < list.length; i++) {
+    var p = list[i];
     if (typeof from[p] != 'undefined') {
       to[p] = from[p];
     }
-  });
+  }
   return to;
 };
 


### PR DESCRIPTION
These changes improve the performance of the `ejs.renderFile()` function by up to about 4x.
To be clear, the improvement is just in the `renderFile()` function, not the entire rendering process.

This increase in performance was achieved by:

+ Not calling `Array.prototype.slice` on the `arguments` object and then manipulating the returned array
+ Creating a global `_OPTS_EXPRESS` variable instead of manipulating the `_OPTS` array on every call to `renderFile()`
+ Moving the try-catch statement into its own function so that `renderFile` may be optimized by V8
+ Using a regular `for` loop in `utils.shallowCopyFromList()` instead of a `forEach` loop

### Benchmark

```js
'use strict';

const Benchmark = require('benchmark');

const ejs = require('ejs');
const ejs2 = require('/path/to/this/branch/ejs');

const filePath = './helloWorld.ejs'; // helloWorld.ejs just contains "Hello World!"
const renderData = {};
const renderOptions = {
  cache: true,
};
function cb() { }

new Benchmark.Suite()
  .add('before - 3 args', () => {
    ejs.renderFile(filePath, renderOptions, cb);
  })
  .add('after - 3 args', () => {
    ejs2.renderFile(filePath, renderOptions, cb);
  })
  .add('before - 4 args', () => {
    ejs.renderFile(filePath, renderData, renderOptions, cb);
  })
  .add('after - 4 args', () => {
    ejs2.renderFile(filePath, renderData, renderOptions, cb);
  })
  .on('cycle', (event) => {
    console.log(String(event.target));
  })
  .run();
```

Results (higher is better):

| # args | before (ops/sec) | after (ops/sec) | speedup factor
|--------|-------------------|------------------|-----------------
| 3         | 186,263              | 431,891            | 2.3
| 4         | 268,917              | 1,017,427          | 3.8

Raw results:

```
before - 3 args x 186,263 ops/sec ±0.82% (93 runs sampled)
after - 3 args x 431,891 ops/sec ±0.54% (97 runs sampled)
before - 4 args x 268,917 ops/sec ±0.45% (95 runs sampled)
after - 4 args x 1,017,427 ops/sec ±0.49% (91 runs sampled)
```