### PR TITLE
add root to default _OPTS in order to allow express set root for ejs

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -55,7 +55,7 @@ var _DEFAULT_LOCALS_NAME = 'locals';
 var _NAME = 'ejs';
 var _REGEX_STRING = '(<%%|%%>|<%=|<%-|<%_|<%#|<%|%>|-%>|_%>)';
 var _OPTS = ['delimiter', 'scope', 'context', 'debug', 'compileDebug',
-  'client', '_with', 'rmWhitespace', 'strict', 'filename'];
+  'client', '_with', 'rmWhitespace', 'strict', 'filename', 'root'];
 // We don't allow 'cache' option to be passed in the data obj
 // for the normal `render` call, but this is where Express puts it
 // so we make an exception for `renderFile`


### PR DESCRIPTION
I see that ejs root can be set in express ,but in current ejs version ,root key isn't in the default _OPTS.So I changed it in my fork and want to merge it to master branch. Hope to pass.