### PR TITLE
Add .npmignore file and don't publish test/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage/
 /ejs.js
 /ejs.min.js
 out/
+pkg/

--- a/.npmignore
+++ b/.npmignore
@@ -19,3 +19,4 @@ npm-debug.log
 doc/
 coverage/
 out/
+pkg/

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,6 @@
-# If you add anything here, consider also adding to .npmignore
+test/
+
+# Copied from .gitignore
 v8.log
 *.swp
 *.swo
@@ -8,7 +10,6 @@ dist
 tags
 nbproject/
 spec/browser/autogen_suite.js
-node_modules
 tmtags
 *.DS_Store
 examples/*/log/*
@@ -16,8 +17,5 @@ site/log/*
 .log
 npm-debug.log
 doc/
-test/tmp
 coverage/
-/ejs.js
-/ejs.min.js
 out/

--- a/Jakefile
+++ b/Jakefile
@@ -59,8 +59,7 @@ publishTask('ejs', ['build'], function () {
     'package.json',
     'ejs.js',
     'ejs.min.js',
-    'lib/**',
-    'test/**'
+    'lib/**'
   ]);
 });
 


### PR DESCRIPTION
The test directory is currently 308K, everything else is 124K.

Not sure if this has already been considered (if so sorry), but not publishing the `test/` directory would make the module much smaller. If people want to run the tests, they can (and probably already are) pulling from GitHub instead.