### PR TITLE
Use consistent object key for escape function

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -431,7 +431,7 @@ function Template(text, opts) {
   this.source = '';
   this.dependencies = [];
   options.client = opts.client || false;
-  options.escapeFunction = opts.escape || utils.escapeXML;
+  options.escapeFunction = opts.escape || opts.escapeFunction || utils.escapeXML;
   options.compileDebug = opts.compileDebug !== false;
   options.debug = !!opts.debug;
   options.filename = opts.filename;


### PR DESCRIPTION
The `escape` option was not being propagated through to included files, since the key was not saved in the `Template` copy of the options. Using the same key for the input and saved copy fixes this.