### PR TITLE
use only one __output array for template and includes

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -481,12 +481,20 @@ Template.prototype = {
 
     if (!this.source) {
       this.generateSource();
-      prepended += '  var __output = [], __append = __output.push.bind(__output);' + '\n';
+      if (opts.client) {
+        prepended += 'var __output = [], __append = caller_append || __output.push.bind(__output);' + '\n';
+      }
+      else {
+        prepended += 'var __append = caller_append;' + '\n';
+      }
+
       if (opts._with !== false) {
         prepended +=  '  with (' + opts.localsName + ' || {}) {' + '\n';
         appended += '  }' + '\n';
       }
-      appended += '  return __output.join("");' + '\n';
+      if (opts.client) {
+        appended += '  if (! caller_append) { return __output.join("");} ' + '\n';
+      }
       this.source = prepended + this.source + appended;
     }
 
@@ -521,7 +529,7 @@ Template.prototype = {
     }
 
     try {
-      fn = new Function(opts.localsName + ', escapeFn, include, rethrow', src);
+      fn = new Function(opts.localsName + ', escapeFn, include, rethrow, caller_append', src);
     }
     catch(e) {
       // istanbul ignore else
@@ -544,15 +552,21 @@ Template.prototype = {
     // Return a callable function which will execute the function
     // created by the source-code, with the passed data as locals
     // Adds a local `include` function which allows full recursive include
-    var returnedFn = function (data) {
+    var returnedFn = function (data, caller_append) {
+      var __output, __append = caller_append;
+      if (! caller_append) {
+        __output = [];
+        __append =  __output.push.bind(__output);
+      }
       var include = function (path, includeData) {
         var d = utils.shallowCopy({}, data);
         if (includeData) {
           d = utils.shallowCopy(d, includeData);
         }
-        return includeFile(path, opts)(d);
+        return includeFile(path, opts)(d, __append);
       };
-      return fn.apply(opts.context, [data || {}, escapeFn, include, rethrow]);
+      fn.apply(opts.context, [data || {}, escapeFn, include, rethrow, __append]);
+      if (! caller_append) { return __output.join(''); }
     };
     returnedFn.dependencies = this.dependencies;
     return returnedFn;

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -482,10 +482,10 @@ Template.prototype = {
     if (!this.source) {
       this.generateSource();
       if (opts.client) {
-        prepended += 'var __output = [], __append = caller_append || __output.push.bind(__output);' + '\n';
+        prepended += 'var __output = [], __append = callerAppend || __output.push.bind(__output);' + '\n';
       }
       else {
-        prepended += 'var __append = caller_append;' + '\n';
+        prepended += 'var __append = callerAppend;' + '\n';
       }
 
       if (opts._with !== false) {
@@ -493,7 +493,7 @@ Template.prototype = {
         appended += '  }' + '\n';
       }
       if (opts.client) {
-        appended += '  if (! caller_append) { return __output.join("");} ' + '\n';
+        appended += '  if (! callerAppend) { return __output.join("");} ' + '\n';
       }
       this.source = prepended + this.source + appended;
     }
@@ -529,7 +529,7 @@ Template.prototype = {
     }
 
     try {
-      fn = new Function(opts.localsName + ', escapeFn, include, rethrow, caller_append', src);
+      fn = new Function(opts.localsName + ', escapeFn, include, rethrow, callerAppend', src);
     }
     catch(e) {
       // istanbul ignore else
@@ -552,9 +552,9 @@ Template.prototype = {
     // Return a callable function which will execute the function
     // created by the source-code, with the passed data as locals
     // Adds a local `include` function which allows full recursive include
-    var returnedFn = function (data, caller_append) {
-      var __output, __append = caller_append;
-      if (! caller_append) {
+    var returnedFn = function (data, callerAppend) {
+      var __output, __append = callerAppend;
+      if (! callerAppend) {
         __output = [];
         __append =  __output.push.bind(__output);
       }
@@ -566,7 +566,7 @@ Template.prototype = {
         return includeFile(path, opts)(d, __append);
       };
       fn.apply(opts.context, [data || {}, escapeFn, include, rethrow, __append]);
-      if (! caller_append) { return __output.join(''); }
+      if (! callerAppend) { return __output.join(''); }
     };
     returnedFn.dependencies = this.dependencies;
     return returnedFn;


### PR DESCRIPTION
This improve performance for Includes.

Old code joins the _output array of each included file separately, and then joins all the results.
Old code also needs to create an _append closure for each included template.

The patch passes the _append of the master template to the includes, and saves time.

-----------
This has a positive side effect: if an include file define a function, and that function is somehow made accessible outside the function file, then calling it will add the functions _append in the place where it is called.
I don't think this will break anythink:
1) Currently such a function would be very hard to archive. It could be added to a local variable, and then used on the outside. 
2) If on did this, it would not get any results with current ejs, because the function would call _append for a _output that has been joined already.

However (as a side effect) this change will allow for such functions become useful in future.
See the branch https://github.com/User4martin/ejs/tree/template_subclass
This branch is an example / not ready for inclusion / I will open a separate discussion on its do-ability 
