### PR TITLE
Test tags

### DIFF
--- a/test/ejs.js
+++ b/test/ejs.js
@@ -734,6 +734,10 @@ suite('%%>', function () {
     assert.equal(ejs.render('  >', {}, {delimiter: ' '}),
         ' >');
   });
+  test('produce literal even with extra %> closing tag', function () {
+    assert.equal(ejs.render('%%> %>'),
+        '%> %>');
+  });
 });
 
 suite('<%_ and _%>', function () {

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -630,6 +630,29 @@ suite('<%-', function () {
   });
 });
 
+suite('ignore additional closing tags', function () {
+  test('only %>', function () {
+    assert.equal(ejs.render('foo %>'),
+      'foo ');
+  });
+  test('only -%> (slurps newline)', function () {
+    assert.equal(ejs.render('foo -%>\n\n'),
+      'foo \n');
+  });
+  test('only -%> (slurps newline)', function () {
+    assert.equal(ejs.render('foo -%>\n\n'),
+      'foo \n');
+  });
+  test('only _%> (slurps spaces)', function () {
+    assert.equal(ejs.render('foo _%>  '),
+      'foo ');
+  });
+  test('mixed %>', function () {
+    assert.equal(ejs.render('foo %> <%= "bar" %> %>%>_%>'),
+      'foo  bar ');
+  });
+});
+
 suite('%>', function () {
   test('produce newlines', function () {
     assert.equal(ejs.render(fixture('newlines.ejs'), {users: users}),

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -628,7 +628,7 @@ suite('<%-', function () {
       assert.ok(err.message.indexOf('Could not find matching close tag for') > -1);
     }
   });
-  
+
   test('terminate gracefully if no close tag is found (double open)', function () {
     try {
       ejs.compile('<h1>oops</h1><%- <%= name -%>');

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -628,6 +628,27 @@ suite('<%-', function () {
       assert.ok(err.message.indexOf('Could not find matching close tag for') > -1);
     }
   });
+  
+  test('terminate gracefully if no close tag is found (double open)', function () {
+    try {
+      ejs.compile('<h1>oops</h1><%- <%= name -%>');
+      throw new Error('Expected parse failure');
+    }
+    catch (err) {
+      assert.ok(err.message.indexOf('Could not find matching close tag for "<%-') > -1);
+    }
+  });
+
+  test('terminate gracefully if no close tag is found (incorrect nesting)', function () {
+    try {
+      ejs.compile('<h1>oops</h1><%- <%= name -%> %>');
+      throw new Error('Expected parse failure');
+    }
+    catch (err) {
+      assert.ok(err.message.indexOf('Could not find matching close tag for "<%-') > -1);
+    }
+  });
+
 });
 
 suite('ignore additional closing tags', function () {


### PR DESCRIPTION
The current behaviour of some closing tags is in my opinion "strange"

But never mind that. This test ensures the current behaviour is not accidentally changed.
I assume that changes to this (if desired) would require appropriate version changes, as they would not be compatible.

Behaviour tested (new):
- any closing %> -%> _%> tag is ignored (silently removed), if it does not have an opening tag.
- ignored closing tags do slurp space/newlines as they would do, if they had an opening tag.
- closing %> tag (not tested for -%> _%>) is handled as literal (copied to new source), if it follows an CLOSING literal 
  e.g  `%%> %>` will give `%> %>`

Behaviour tested (already tested in existing test case):
- closing %> tag (not tested for -%> _%>) is handled as literal (copied to new source), if it follows an opening literal 
  e.g  `<%% %>` will give `<% %>`

There are no test for literals in embedded js code.  ` <%= "<%% foo"  %>` 
(They break the embedded code, as they change this.mode)
