### PR TITLE
Refactor generate source

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -609,17 +609,6 @@ Template.prototype = {
         var includeOpts;
         var includeObj;
         var includeSrc;
-        // If this is an opening tag, check for closing tags
-        // FIXME: May end up with some false positives here
-        // Better to store modes as k/v with '<' + delimiter as key
-        // Then this can simply check against the map
-        if ( line.indexOf('<' + d) === 0        // If it is a tag
-          && line.indexOf('<' + d + d) !== 0) { // and is not escaped
-          closing = matches[index + 2];
-          if (!(closing == d + '>' || closing == '-' + d + '>' || closing == '_' + d + '>')) {
-            throw new Error('Could not find matching close tag for "' + line + '".');
-          }
-        }
         // HACK: backward-compat `include` preprocessor directives
         if ((include = line.match(/^\s*include\s+(\S+)/))) {
           opening = matches[index - 1];
@@ -651,6 +640,8 @@ Template.prototype = {
         }
         self.scanLine(line);
       });
+      if (this.isInTag)
+        throw new Error('Could not find matching close tag for "' + this.isInTag + '".');
     }
 
   },
@@ -721,75 +712,97 @@ Template.prototype = {
 
     newLineCount = (line.split('\n').length - 1);
 
-    switch (line) {
-    case '<' + d:
-    case '<' + d + '_':
-      this.mode = Template.modes.EVAL;
-      break;
-    case '<' + d + '=':
-      this.mode = Template.modes.ESCAPED;
-      break;
-    case '<' + d + '-':
-      this.mode = Template.modes.RAW;
-      break;
-    case '<' + d + '#':
-      this.mode = Template.modes.COMMENT;
-      break;
-    case '<' + d + d:
-      this.mode = Template.modes.LITERAL;
-      this.source += '    ; __append("' + line.replace('<' + d + d, '<' + d) + '")' + '\n';
-      break;
-    case d + d + '>':
-      this.mode = Template.modes.LITERAL;
-      this.source += '    ; __append("' + line.replace(d + d + '>', d + '>') + '")' + '\n';
-      break;
-    case d + '>':
-    case '-' + d + '>':
-    case '_' + d + '>':
-      if (this.mode == Template.modes.LITERAL) {
-        this._addOutput(line);
+    var isHandled;
+    if (line[0] == '<') {
+      isHandled = true;
+      switch (line) {
+      case '<' + d:
+      case '<' + d + '_':
+        this.mode = Template.modes.EVAL;
+        break;
+      case '<' + d + '=':
+        this.mode = Template.modes.ESCAPED;
+        break;
+      case '<' + d + '-':
+        this.mode = Template.modes.RAW;
+        break;
+      case '<' + d + '#':
+        this.mode = Template.modes.COMMENT;
+        break;
+      case '<' + d + d:
+        this.mode = Template.modes.LITERAL;
+        this.source += '    ; __append("' + line.replace('<' + d + d, '<' + d) + '")' + '\n';
+        break;
+      default:
+        isHandled = false;
       }
-
-      this.mode = null;
-      this.truncate = line.indexOf('-') === 0 || line.indexOf('_') === 0;
-      break;
-    default:
-        // In script mode, depends on type of tag
-      if (this.mode) {
-          // If '//' is found without a line break, add a line break.
-        switch (this.mode) {
-        case Template.modes.EVAL:
-        case Template.modes.ESCAPED:
-        case Template.modes.RAW:
-          if (line.lastIndexOf('//') > line.lastIndexOf('\n')) {
-            line += '\n';
+      if (isHandled && this.mode != Template.modes.LITERAL) {
+        if (this.isInTag)
+          throw new Error('Could not find matching close tag for "' + this.isInTag + '".');
+        this.isInTag = line;
+      }
+    }
+    if (! isHandled) {
+      if (line[line.length-1] == '>') {
+        isHandled = true;
+        switch (line) {
+        case d + d + '>':
+          this.mode = Template.modes.LITERAL;
+          this.source += '    ; __append("' + line.replace(d + d + '>', d + '>') + '")' + '\n';
+          break;
+        case d + '>':
+        case '-' + d + '>':
+        case '_' + d + '>':
+          this.isInTag = undefined;
+          if (this.mode == Template.modes.LITERAL) {
+            this._addOutput(line);
+          }
+    
+          this.mode = null;
+          this.truncate = line.indexOf('-') === 0 || line.indexOf('_') === 0;
+          break;
+        default:
+          isHandled = false;
+        }
+      }
+      if (! isHandled) {
+          // In script mode, depends on type of tag
+        if (this.mode) {
+            // If '//' is found without a line break, add a line break.
+          switch (this.mode) {
+          case Template.modes.EVAL:
+          case Template.modes.ESCAPED:
+          case Template.modes.RAW:
+            if (line.lastIndexOf('//') > line.lastIndexOf('\n')) {
+              line += '\n';
+            }
+          }
+          switch (this.mode) {
+              // Just executing code
+          case Template.modes.EVAL:
+            this.source += '    ; ' + line + '\n';
+            break;
+              // Exec, esc, and output
+          case Template.modes.ESCAPED:
+            this.source += '    ; __append(escapeFn(' + stripSemi(line) + '))' + '\n';
+            break;
+              // Exec and output
+          case Template.modes.RAW:
+            this.source += '    ; __append(' + stripSemi(line) + ')' + '\n';
+            break;
+          case Template.modes.COMMENT:
+                // Do nothing
+            break;
+              // Literal <%% mode, append as raw output
+          case Template.modes.LITERAL:
+            this._addOutput(line);
+            break;
           }
         }
-        switch (this.mode) {
-            // Just executing code
-        case Template.modes.EVAL:
-          this.source += '    ; ' + line + '\n';
-          break;
-            // Exec, esc, and output
-        case Template.modes.ESCAPED:
-          this.source += '    ; __append(escapeFn(' + stripSemi(line) + '))' + '\n';
-          break;
-            // Exec and output
-        case Template.modes.RAW:
-          this.source += '    ; __append(' + stripSemi(line) + ')' + '\n';
-          break;
-        case Template.modes.COMMENT:
-              // Do nothing
-          break;
-            // Literal <%% mode, append as raw output
-        case Template.modes.LITERAL:
+          // In string mode, just add the output
+        else {
           this._addOutput(line);
-          break;
         }
-      }
-        // In string mode, just add the output
-      else {
-        this._addOutput(line);
       }
     }
 

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -601,11 +601,12 @@ Template.prototype = {
     var matches = this.parseTemplateText();
 
     if (matches && matches.length) {
-      matches.forEach(function (line, index) {
+      matches.forEach(function (line) {
         self.scanLine(line);
       });
-      if (this.isInTag)
+      if (this.isInTag) {
         throw new Error('Could not find matching close tag for "' + this.isInTag + '".');
+      }
     }
 
   },
@@ -701,8 +702,9 @@ Template.prototype = {
         isHandled = false;
       }
       if (isHandled && this.mode != Template.modes.LITERAL) {
-        if (this.isInTag)
+        if (this.isInTag) {
           throw new Error('Could not find matching close tag for "' + this.isInTag + '".');
+        }
         this.isInTag = line;
         this.isAfterTag = true;
       }

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -599,45 +599,9 @@ Template.prototype = {
 
     var self = this;
     var matches = this.parseTemplateText();
-    var d = this.opts.delimiter;
 
     if (matches && matches.length) {
       matches.forEach(function (line, index) {
-        var opening;
-        var closing;
-        var include;
-        var includeOpts;
-        var includeObj;
-        var includeSrc;
-        // HACK: backward-compat `include` preprocessor directives
-        if ((include = line.match(/^\s*include\s+(\S+)/))) {
-          opening = matches[index - 1];
-          // Must be in EVAL or RAW mode
-          if (opening && (opening == '<' + d || opening == '<' + d + '-' || opening == '<' + d + '_')) {
-            includeOpts = utils.shallowCopy({}, self.opts);
-            includeObj = includeSource(include[1], includeOpts);
-            if (self.opts.compileDebug) {
-              includeSrc =
-                  '    ; (function(){' + '\n'
-                  + '      var __line = 1' + '\n'
-                  + '      , __lines = ' + JSON.stringify(includeObj.template) + '\n'
-                  + '      , __filename = ' + JSON.stringify(includeObj.filename) + ';' + '\n'
-                  + '      try {' + '\n'
-                  + includeObj.source
-                  + '      } catch (e) {' + '\n'
-                  + '        rethrow(e, __lines, __filename, __line, escapeFn);' + '\n'
-                  + '      }' + '\n'
-                  + '    ; }).call(this)' + '\n';
-            }else{
-              includeSrc = '    ; (function(){' + '\n' + includeObj.source +
-                  '    ; }).call(this)' + '\n';
-            }
-            self.source += includeSrc;
-            self.dependencies.push(exports.resolveInclude(include[1],
-                includeOpts.filename));
-            return;
-          }
-        }
         self.scanLine(line);
       });
       if (this.isInTag)
@@ -740,6 +704,7 @@ Template.prototype = {
         if (this.isInTag)
           throw new Error('Could not find matching close tag for "' + this.isInTag + '".');
         this.isInTag = line;
+        this.isAfterTag = true;
       }
     }
     if (! isHandled) {
@@ -771,8 +736,39 @@ Template.prototype = {
             // If '//' is found without a line break, add a line break.
           switch (this.mode) {
           case Template.modes.EVAL:
-          case Template.modes.ESCAPED:
           case Template.modes.RAW:
+            // HACK: backward-compat `include` preprocessor directives
+            if (this.isAfterTag && (include = line.match(/^\s*include\s+(\S+)/))) {
+              var include, includeOpts, includeObj, includeSrc;
+              includeOpts = utils.shallowCopy({}, self.opts);
+              includeObj = includeSource(include[1], includeOpts);
+              if (self.opts.compileDebug) {
+                includeSrc =
+                    '    ; (function(){' + '\n'
+                    + '      var __line = 1' + '\n'
+                    + '      , __lines = ' + JSON.stringify(includeObj.template) + '\n'
+                    + '      , __filename = ' + JSON.stringify(includeObj.filename) + ';' + '\n'
+                    + '      try {' + '\n'
+                    + includeObj.source
+                    + '      } catch (e) {' + '\n'
+                    + '        rethrow(e, __lines, __filename, __line, escapeFn);' + '\n'
+                    + '      }' + '\n'
+                    + '    ; }).call(this)' + '\n';
+              }else{
+                includeSrc = '    ; (function(){' + '\n' + includeObj.source +
+                    '    ; }).call(this)' + '\n';
+              }
+              self.source += includeSrc;
+              self.dependencies.push(exports.resolveInclude(include[1],
+                  includeOpts.filename));
+              return; // TODO: debug info
+            }
+            // END HACH include
+            if (line.lastIndexOf('//') > line.lastIndexOf('\n')) {
+              line += '\n';
+            }
+            break;
+          case Template.modes.ESCAPED:
             if (line.lastIndexOf('//') > line.lastIndexOf('\n')) {
               line += '\n';
             }
@@ -804,6 +800,7 @@ Template.prototype = {
           this._addOutput(line);
         }
       }
+      this.isAfterTag = false;
     }
 
     if (self.opts.compileDebug && newLineCount) {

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -724,7 +724,7 @@ Template.prototype = {
           if (this.mode == Template.modes.LITERAL) {
             this._addOutput(line);
           }
-    
+
           this.mode = null;
           this.truncate = line.indexOf('-') === 0 || line.indexOf('_') === 0;
           break;
@@ -740,10 +740,11 @@ Template.prototype = {
           case Template.modes.EVAL:
           case Template.modes.RAW:
             // HACK: backward-compat `include` preprocessor directives
+            var include;
             if (this.isAfterTag && (include = line.match(/^\s*include\s+(\S+)/))) {
-              var include, includeOpts, includeObj, includeSrc;
-              includeOpts = utils.shallowCopy({}, self.opts);
-              includeObj = includeSource(include[1], includeOpts);
+              var includeSrc;
+              var includeOpts = utils.shallowCopy({}, self.opts);
+              var includeObj = includeSource(include[1], includeOpts);
               if (self.opts.compileDebug) {
                 includeSrc =
                     '    ; (function(){' + '\n'


### PR DESCRIPTION
Moved the check for missing closing tags to scanLine.

**Commit 1:**

This does
- slightly improve performance
- make future changes to the behaviour easier to implement. See #277 

Also added some "if" around the "switch" statements.
This improves performance.

**Commit 2**

Moved the old `include file` code to scanLine.
No direct benefit in execution. But I thought it just would be cleaner.

----
Benchmarks

Old code

    bench-ejs.js -r 15   --compile
    Running avg accross:  15
    name:                          avg        med        med/avg    min        max                  loops
    single tmpl compile:           1.819      1.829      1.83       1.671      1.916                20000
    single tmpl compile (debug):   2.112      2.103      2.104      2.028      2.214                20000
    large tmpl compile:            6.621      6.674      6.648      6.175      7.044                 1000
    include-1 compile:             1.262      1.263      1.26       1.151      1.339                20000

New code

    bench-ejs.js -r 15   --compile
    Running avg accross:  15
    name:                          avg        med        med/avg    min        max                  loops
    single tmpl compile:           1.465      1.466      1.464      1.325      1.637                20000
    single tmpl compile (debug):   1.69       1.681      1.688      1.552      1.784                20000
    large tmpl compile:            4.84       4.82       4.836      4.613      5.129                 1000
    include-1 compile:             1.061      1.06       1.061      1.015      0.985                20000
