### PR TITLE
Adding simple change to _OPTS_EXPRESS (including root)

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -59,7 +59,7 @@ var _OPTS = ['delimiter', 'scope', 'context', 'debug', 'compileDebug',
 // We don't allow 'cache' option to be passed in the data obj
 // for the normal `render` call, but this is where Express puts it
 // so we make an exception for `renderFile`
-var _OPTS_EXPRESS = _OPTS.concat('cache');
+var _OPTS_EXPRESS = _OPTS.concat(['cache','root']);
 var _BOM = /^\uFEFF/;
 
 /**


### PR DESCRIPTION
Maybe I'm missing something, but unless there isn't an historical (or some other) good reason to leave it out of the params that ejs "allows" when used with Express, I think it could/would be helpful to allow for the `root` param to be enabled for this context.