### PR TITLE
rename callerAppend in template

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -508,10 +508,7 @@ Template.prototype = {
     if (!this.source) {
       this.generateSource();
       if (opts.client) {
-        prepended += 'var __output = [], __append = callerAppend || __output.push.bind(__output);' + '\n';
-      }
-      else {
-        prepended += 'var __append = callerAppend;' + '\n';
+        prepended += 'var __output; if (! __append) { __output = []; __append = __output.push.bind(__output); }' + '\n';
       }
 
       if (opts._with !== false) {
@@ -519,7 +516,7 @@ Template.prototype = {
         appended += '  }' + '\n';
       }
       if (opts.client) {
-        appended += '  if (! callerAppend) { return __output.join("");} ' + '\n';
+        appended += '  if (__output) { return __output.join("");} ' + '\n';
       }
       this.source = prepended + this.source + appended;
     }
@@ -554,7 +551,7 @@ Template.prototype = {
     }
 
     try {
-      fn = new Function(opts.localsName + ', escapeFn, include, rethrow, callerAppend', src);
+      fn = new Function(opts.localsName + ', escapeFn, include, rethrow, __append', src);
     }
     catch(e) {
       // istanbul ignore else


### PR DESCRIPTION
just a small adjustment to #272 

Avoid defining the name "callerAppend" in the compiled/evaluated template.

There is no real problem with "callerAppend" being used, since the `with (' + opts.localsName + ' || {}) {` inside the function has higher prior. So user code in template referring to "callerAppend" would have gotten locals.callerAppend anyway.

I just feel it may be cleaner this way
