### PR TITLE
revert 8aaa1205cfc79251f85cdab954d4ce3ef37cd3bf use only one __output…

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -507,20 +507,12 @@ Template.prototype = {
 
     if (!this.source) {
       this.generateSource();
-      if (opts.client) {
-        prepended += 'var __output = [], __append = callerAppend || __output.push.bind(__output);' + '\n';
-      }
-      else {
-        prepended += 'var __append = callerAppend;' + '\n';
-      }
-
+      prepended += '  var __output = [], __append = __output.push.bind(__output);' + '\n';
       if (opts._with !== false) {
         prepended +=  '  with (' + opts.localsName + ' || {}) {' + '\n';
         appended += '  }' + '\n';
       }
-      if (opts.client) {
-        appended += '  if (! callerAppend) { return __output.join("");} ' + '\n';
-      }
+      appended += '  return __output.join("");' + '\n';
       this.source = prepended + this.source + appended;
     }
 
@@ -554,7 +546,7 @@ Template.prototype = {
     }
 
     try {
-      fn = new Function(opts.localsName + ', escapeFn, include, rethrow, callerAppend', src);
+      fn = new Function(opts.localsName + ', escapeFn, include, rethrow', src);
     }
     catch(e) {
       // istanbul ignore else
@@ -577,22 +569,15 @@ Template.prototype = {
     // Return a callable function which will execute the function
     // created by the source-code, with the passed data as locals
     // Adds a local `include` function which allows full recursive include
-    var returnedFn = function (data, callerAppend) {
-      var __output;
-      var __append = callerAppend;
-      if (! callerAppend) {
-        __output = [];
-        __append =  __output.push.bind(__output);
-      }
+    var returnedFn = function (data) {
       var include = function (path, includeData) {
         var d = utils.shallowCopy({}, data);
         if (includeData) {
           d = utils.shallowCopy(d, includeData);
         }
-        return includeFile(path, opts)(d, __append);
+        return includeFile(path, opts)(d);
       };
-      fn.apply(opts.context, [data || {}, escapeFn, include, rethrow, __append]);
-      if (! callerAppend) { return __output.join(''); }
+      return fn.apply(opts.context, [data || {}, escapeFn, include, rethrow]);
     };
     returnedFn.dependencies = this.dependencies;
     return returnedFn;


### PR DESCRIPTION
As commented on #272 
The feature broke `<%-include('foo')%>` so this pull request reverts the change. 

Users could use `<%= include('foo') %>`
E.g. foo contains plain text, that needs to be html escaped.
But this requires that include must return a string.

Or more exotic  `<%-include('foo').replace(/bar/g, 'other')%>`
