### PR TITLE
feat(tag): Add whitespace-trim mode to output tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ $ npm install ejs
 
   * Control flow with `<% %>`
   * Escaped output with `<%= %>` (escape function configurable)
+  * Escaped output, stripping all whitespace before it with `<%=_ %>` (escape function configurable)
   * Unescaped raw output with `<%- %>`
+  * Unescaped raw output, stripping all whitespace before it with`<%-_ %>`
   * Newline-trim mode ('newline slurping') with `-%>` ending tag
   * Whitespace-trim mode (slurp all whitespace) for control flow with `<%_ _%>`
   * Custom delimiters (e.g., use `<? ?>` instead of `<% %>`)
@@ -90,7 +92,9 @@ the both the public & private API docs, run `npm run devdoc` instead.
   - `<%`              'Scriptlet' tag, for control-flow, no output
   - `<%_`             'Whitespace Slurping' Scriptlet tag, strips all whitespace before it
   - `<%=`             Outputs the value into the template (escaped)
+  - `<%=_`            Outputs the value into the template (escaped), strips all whitespace before it
   - `<%-`             Outputs the unescaped value into the template
+  - `<%-_`            Outputs the unescaped value into the template, strips all whitespace before it
   - `<%#`             Comment tag, no execution, no output
   - `<%%`             Outputs a literal '<%'
   - `%%>`             Outputs a literal '%>'

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -53,7 +53,7 @@ var _VERSION_STRING = require('../package.json').version;
 var _DEFAULT_DELIMITER = '%';
 var _DEFAULT_LOCALS_NAME = 'locals';
 var _NAME = 'ejs';
-var _REGEX_STRING = '(<%%|%%>|<%=|<%-|<%_|<%#|<%|%>|-%>|_%>)';
+var _REGEX_STRING = '(<%%|%%>|<%=_|<%-_|<%=|<%-|<%_|<%#|<%|%>|-%>|_%>)';
 var _OPTS = ['delimiter', 'scope', 'context', 'debug', 'compileDebug',
   'client', '_with', 'rmWhitespace', 'strict', 'filename'];
 // We don't allow 'cache' option to be passed in the data obj
@@ -595,7 +595,7 @@ Template.prototype = {
 
     // Slurp spaces and tabs before <%_ and after _%>
     this.templateText =
-      this.templateText.replace(/[ \t]*<%_/gm, '<%_').replace(/_%>[ \t]*/gm, '_%>');
+      this.templateText.replace(/[ \t]*<%=_/gm, '<%=_').replace(/[ \t]*<%-_/gm, '<%-_').replace(/[ \t]*<%_/gm, '<%_').replace(/_%>[ \t]*/gm, '_%>');
 
     var self = this;
     var matches = this.parseTemplateText();
@@ -726,9 +726,11 @@ Template.prototype = {
     case '<' + d + '_':
       this.mode = Template.modes.EVAL;
       break;
+    case '<' + d + '=_':
     case '<' + d + '=':
       this.mode = Template.modes.ESCAPED;
       break;
+    case '<' + d + '-_':
     case '<' + d + '-':
       this.mode = Template.modes.RAW;
       break;


### PR DESCRIPTION
**feature:** Add expression/output tag with support of whitespace slurping.

The tag is a combination of `<%=`+`<%_`.

Tag introduced `<%=_` and `<%-_`

Proposal for issue #289.

**TODO:**
If needed update test cases.