### PR TITLE
feat: add support for setting fileLoader via opts

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -177,6 +177,7 @@ function handleCache(options, template) {
   var func;
   var filename = options.filename;
   var hasTemplate = arguments.length > 1;
+  var fileLoaderFn = options.fileLoader || fileLoader;
 
   if (options.cache) {
     if (!filename) {
@@ -187,7 +188,7 @@ function handleCache(options, template) {
       return func;
     }
     if (!hasTemplate) {
-      template = fileLoader(filename).toString().replace(_BOM, '');
+      template = fileLoaderFn(filename).toString().replace(_BOM, '');
     }
   }
   else if (!hasTemplate) {
@@ -196,7 +197,7 @@ function handleCache(options, template) {
       throw new Error('Internal EJS error: no file name or template '
                     + 'provided');
     }
-    template = fileLoader(filename).toString().replace(_BOM, '');
+    template = fileLoaderFn(filename).toString().replace(_BOM, '');
   }
   func = exports.compile(template, options);
   if (options.cache) {
@@ -400,7 +401,7 @@ exports.render = function (template, d, o) {
 exports.renderFile = function () {
   var filename = arguments[0];
   var cb = arguments[arguments.length - 1];
-  var opts = {filename: filename};
+  var opts = utils.shallowCopy({filename: filename}, arguments[arguments.length - 2]);
   var data;
 
   if (arguments.length > 2) {

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -1100,7 +1100,18 @@ suite('test fileloader', function () {
     return 'myFileLoad: ' + fs.readFileSync(filePath);
   };
 
-  test('test custom fileload', function (done) {
+  test('test custom fileload via options', function (done) {
+    ejs.renderFile('test/fixtures/para.ejs', null, { fileLoader: myFileLoad }, function(err, html) {
+      if (err) {
+        return done(err);
+      }
+      assert.equal(html, 'myFileLoad: <p>hey</p>\n');
+      done();
+    });
+
+  });
+
+  test('test custom fileload via global ejs object', function (done) {
     ejs.fileLoader = myFileLoad;
     ejs.renderFile('test/fixtures/para.ejs', function(err, html) {
       if (err) {


### PR DESCRIPTION
Currently fileLoader can only be defined by setting it on the exported ejs object. This PR adds support for also setting fileLoader via options, which in turn will set it on the ejs object.

Closes #310