### PR TITLE
Fixes #358, enables rendering options to be passed in from Express

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ documentation, clone the repository and run `npm run doc`. This will run JSDoc
 with the proper options and output the documentation to `out/`. If you want
 the both the public & private API docs, run `npm run devdoc` instead.
 
+
+### Using with Express
+
+There are times where you want to pass options to EJS when using with Express. To do that, simply define `view options` property on the Express app settings table, then pass in the option as an object.
+
+For example, to enable `rmWhitespace`:
+
+```javascript
+app.set('view options', { rmWhitespace: true });
+```
+
+__Note__ not all EJS options are available due to security reasons. The list of available options can be found in `_OPTS_EXPRESS` array.
+
 ## Tags
 
   - `<%`              'Scriptlet' tag, for control-flow, no output
@@ -194,18 +207,6 @@ including headers and footers, like so:
 </p>
 <%- include('footer') -%>
 ```
-
-## Express Integration
-
-There are times where you want to pass options to EJS when using with Express. To do that, simply define `view options` property on the Express app settings table, then pass in the option as an object.
-
-For example, to enable `rmWhitespace`:
-
-```javascript
-app.set('view options', { rmWhitespace: true });
-```
-
-__Note__ not all EJS options are available due to security reasons. The list of available options can be found in `_OPTS_EXPRESS` array.
 
 ## Client-side support
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,18 @@ including headers and footers, like so:
 <%- include('footer') -%>
 ```
 
+## Express Integration
+
+There are times where you want to pass options to EJS when using with Express. To do that, simply define `view options` property on the Express app settings table, then pass in the option as an object.
+
+For example, to enable `rmWhitespace`:
+
+```javascript
+app.set('view options', { rmWhitespace: true });
+```
+
+__Note__ not all EJS options are available due to security reasons. The list of available options can be found in `_OPTS_EXPRESS` array.
+
 ## Client-side support
 
 Go to the [Latest Release](https://github.com/mde/ejs/releases/latest), download

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -454,6 +454,9 @@ exports.renderFile = function () {
         if (data.settings.views) {
           opts.views = data.settings.views;
         }
+        if (data.settings['view options']) {
+          utils.shallowCopyFromList(opts, data.settings['view options'], _OPTS_EXPRESS);
+        }
         if (data.settings['view cache']) {
           opts.cache = true;
         }


### PR DESCRIPTION
Adds back the ability to use `view options` property so rendering options can be passed in from Express' application setting table.

For example, to enable `rmWhitespace` option:

```js
app.set('view options', { rmWhitespace: true });
```