### PR TITLE
Exposed includeFile() for modification of the implementer

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -283,11 +283,11 @@ function fileLoader(filePath){
  * @static
  */
 
-function includeFile(path, options) {
+exports.includeFile = function includeFile(path, options) {
   var opts = utils.shallowCopy({}, options);
   opts.filename = getIncludePath(path, opts);
   return handleCache(opts);
-}
+};
 
 /**
  * Get the JavaScript source of an included file.
@@ -648,7 +648,7 @@ Template.prototype = {
         if (includeData) {
           d = utils.shallowCopy(d, includeData);
         }
-        return includeFile(path, opts)(d);
+        return exports.includeFile(path, opts)(d);
       };
       return fn.apply(opts.context, [data || {}, escapeFn, include, rethrow]);
     };


### PR DESCRIPTION
I needed to modify the paths of included files on the fly for each single include. To be able to do this I had to expose includeFile(). All tests are passing and no new lines were added. I cannot find a reason in my head not to do this. :)