### PR TITLE
Fix problems with rmWhitespace

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -669,9 +669,9 @@ Template.prototype = {
 
     if (opts.rmWhitespace) {
       // Have to use two separate replace here as `^` and `$` operators don't
-      // work well with `\r`.
+      // work well with `\r` and empty lines don't work well with the `m` flag.
       this.templateText =
-        this.templateText.replace(/\r/g, '').replace(/^\s+|\s+$/gm, '');
+        this.templateText.replace(/[\r\n]+/g, '\n').replace(/^\s+|\s+$/gm, '');
     }
 
     // Slurp spaces and tabs before <%_ and after _%>
@@ -774,11 +774,6 @@ Template.prototype = {
       // combo first in the regex-or
       line = line.replace(/^(?:\r\n|\r|\n)/, '');
       this.truncate = false;
-    }
-    else if (this.opts.rmWhitespace) {
-      // rmWhitespace has already removed trailing spaces, just need
-      // to remove linebreaks
-      line = line.replace(/^\n/, '');
     }
     if (!line) {
       return line;

--- a/test/fixtures/rmWhitespace.ejs
+++ b/test/fixtures/rmWhitespace.ejs
@@ -8,7 +8,16 @@ adsffadsfadsfad<%= f %>
 piece of text.
 <% var a = 'a' %>  
 Text again.
+<% var aa = a + 'a' %>
+Raw output:
+<%- aa %>
+Blank
+
+Line
 <% var b = 'b' %>
 <% var c = 'c'
 var d = 'd' %>
-Another text. <%= c %>  
+Another text. <%= c %>
+After escaped
+<% /* newline slurp */ -%>
+Last line

--- a/test/fixtures/rmWhitespace.html
+++ b/test/fixtures/rmWhitespace.html
@@ -2,7 +2,19 @@
 <tag2>
 A very long piece of text very long piece of text very long piece of
 text very long piece of text very long piece of
-text very long piece oftext very long
-adsffadsfadsfadfpiece of text.
+tex
+t very long piece oftext very long
+adsffadsfadsfadf
+piece of text.
+
 Text again.
+
+Raw output:
+aa
+Blank
+Line
+
+
 Another text. c
+After escaped
+Last line


### PR DESCRIPTION
Make `rmWhitespace` safer by handling empty lines better and *not* removing newlines around EJS tags.

Fixes #406

### Example

```html
<h2>
  <%- 'EJS' %>
  Title
</h2>
<div>
  <span>1</span>
  <span>2</span>

  <span>3</span>
</div>
```

Before:

```html
<h2>
EJSTitle
</h2>
<div>
<span>1</span>
<span>2</span><span>3</span>
</div>
```

After:

```html
<h2>
EJS
Title
</h2>
<div>
<span>1</span>
<span>2</span>
<span>3</span>
</div>
```