### PR TITLE
getIncludePath() can handle views being a string

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -153,6 +153,9 @@ function getIncludePath(path, options) {
     }
     // Then look in any views directories
     if (!includePath) {
+      if (typeof views === 'string') {
+        views = [].concat(views);
+      }
       if (Array.isArray(views) && views.some(function (v) {
         filePath = exports.resolveInclude(path, v, true);
         return fs.existsSync(filePath);


### PR DESCRIPTION
Implementation of the check in [#415](https://github.com/mde/ejs/issues/415).

If views is a string and not an array of strings, it can still use the path. There's a type check for `string` to prevent any trouble if views is `undefined`.