### PR TITLE
Add missing template dependencies

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -314,7 +314,8 @@ function includeSource(path, options) {
   return {
     source: templ.source,
     filename: includePath,
-    template: template
+    template: template,
+    dependencies: templ.dependencies
   };
 }
 
@@ -500,6 +501,14 @@ exports.clearCache = function () {
   exports.cache.reset();
 };
 
+function onlyUnique(value, index, self) {
+  return self.indexOf(value) === index;
+}
+
+function uniq(array) {
+  return array.filter(onlyUnique);
+}
+
 function Template(text, opts) {
   opts = opts || {};
   var options = {};
@@ -681,7 +690,7 @@ Template.prototype = {
       };
       return fn.apply(opts.context, [data || {}, escapeFn, include, rethrow]);
     };
-    returnedFn.dependencies = this.dependencies;
+    returnedFn.dependencies = uniq(this.dependencies);
     if (opts.filename && typeof Object.defineProperty === 'function') {
       var filename = opts.filename;
       var basename = path.basename(filename, path.extname(filename));
@@ -762,8 +771,20 @@ Template.prototype = {
             self.source += includeSrc;
             self.dependencies.push(exports.resolveInclude(include[1],
               includeOpts.filename));
+            includeObj.dependencies.forEach(function(dep) {
+              self.dependencies.push(dep);
+            });
             return;
           }
+        } else if ((include = line.match(/^\s*include\(\s*['"](\S+)['"].*\)/))) {
+          includeOpts = utils.shallowCopy({}, self.opts);
+          includeObj = includeSource(include[1], includeOpts);
+          self.dependencies.push(
+            exports.resolveInclude(include[1], includeOpts.filename)
+          );
+          includeObj.dependencies.forEach(function(dep) {
+            self.dependencies.push(dep);
+          });
         }
         self.scanLine(line);
       });

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -1151,7 +1151,7 @@ suite('preprocessor include', function () {
   test('tracks dependency correctly', function () {
     var file = 'test/fixtures/menu_preprocessor.ejs';
     var fn = ejs.compile(fixture('menu_preprocessor.ejs'), {filename: file});
-    assert(fn.dependencies.length);
+    assert.ok(fn.dependencies.length > 0);
   });
 
   test('include arbitrary files as-is', function () {
@@ -1232,6 +1232,35 @@ suite('preprocessor include', function () {
       return;
     }
     throw new Error('expected SyntaxError from legacy include being disabled');
+  });
+});
+
+suite('tracks dependency', function () {
+  test('tracks transitive dependency correctly - with parenthesis', function () {
+    var file = 'test/fixtures/track-dependencies-with-parenthesis.ejs';
+    var fn = ejs.compile(fixture('track-dependencies-with-parenthesis.ejs'), { filename: file });
+    // only 2 dependencies : simple.ejs and simple-with-parenthesis.ejs
+    assert.equal(fn.dependencies.length, 2);
+    assert.ok(fn.dependencies.indexOf(__dirname + '/fixtures/includes/simple.ejs') > -1);
+    assert.ok(fn.dependencies.indexOf(__dirname + '/fixtures/includes/simple-with-parenthesis.ejs') > -1);
+  });
+
+  test('tracks transitive dependency correctly - without parenthesis (legacy include)', function () {
+    var file = 'test/fixtures/track-dependencies-without-parenthesis.ejs';
+    var fn = ejs.compile(fixture('track-dependencies-without-parenthesis.ejs'), { filename: file });
+    // only 2 dependencies : simple.ejs and simple-without-parenthesis.ejs
+    assert.equal(fn.dependencies.length, 2);
+    assert.ok(fn.dependencies.indexOf(__dirname + '/fixtures/includes/simple.ejs') > -1);
+    assert.ok(fn.dependencies.indexOf(__dirname + '/fixtures/includes/simple-without-parenthesis.ejs') > -1);
+  });
+
+  test('tracks transitive dependency correctly - without duplicates', function () {
+    var file = 'test/fixtures/track-dependencies-without-duplicates.ejs';
+    var fn = ejs.compile(fixture('track-dependencies-without-duplicates.ejs'), { filename: file });
+    // only 2 dependencies : simple.ejs and simple-with-parenthesis.ejs
+    assert.equal(fn.dependencies.length, 2);
+    assert.ok(fn.dependencies.indexOf(__dirname + '/fixtures/includes/simple.ejs') > -1);
+    assert.ok(fn.dependencies.indexOf(__dirname + '/fixtures/includes/simple-with-parenthesis.ejs') > -1);
   });
 });
 

--- a/test/fixtures/includes/simple-with-parenthesis.ejs
+++ b/test/fixtures/includes/simple-with-parenthesis.ejs
@@ -1,0 +1,2 @@
+This is 'simple-with-parenthesis' template.
+<% include('simple') %>

--- a/test/fixtures/includes/simple-without-parenthesis.ejs
+++ b/test/fixtures/includes/simple-without-parenthesis.ejs
@@ -1,0 +1,2 @@
+This is 'simple-without-parenthesis' template.
+<% include simple %>

--- a/test/fixtures/includes/simple.ejs
+++ b/test/fixtures/includes/simple.ejs
@@ -1,0 +1,1 @@
+This is 'simple' template.

--- a/test/fixtures/track-dependencies-with-parenthesis.ejs
+++ b/test/fixtures/track-dependencies-with-parenthesis.ejs
@@ -1,0 +1,1 @@
+<% include('includes/simple-with-parenthesis') -%>

--- a/test/fixtures/track-dependencies-without-duplicates.ejs
+++ b/test/fixtures/track-dependencies-without-duplicates.ejs
@@ -1,0 +1,3 @@
+<% include('includes/simple-with-parenthesis') -%>
+<% include('includes/simple-with-parenthesis') -%>
+<% include('includes/simple-with-parenthesis') -%>

--- a/test/fixtures/track-dependencies-without-parenthesis.ejs
+++ b/test/fixtures/track-dependencies-without-parenthesis.ejs
@@ -1,0 +1,1 @@
+<% include includes/simple-without-parenthesis -%>


### PR DESCRIPTION
This PR fix #426 and also fix #427. Those are different bugs but they are close so that they are fixed together.

The added regex for parenthesis include can match those patterns : 
```
/^\s*include\(\s*['"](\S+)['"].*\)/

include('../ejs/footer.ejs')
include(   '../ejs/footer.ejs')
include(  '../ejs/footer.ejs'   )
include('../ejs/footer.ejs',    {woot:'bla'})
include("../ejs/footer.ejs")
include(   "../ejs/footer.ejs")
include(  "../ejs/footer.ejs"   )
include("../ejs/footer.ejs",    {woot:'bla'})
```
