### PR TITLE
add remove function to cache

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -158,6 +158,9 @@ exports.cache = {
   get: function (key) {
     return this._data[key];
   },
+  remove: function (key) {
+    delete this._data[key];
+  },
   reset: function () {
     this._data = {};
   }


### PR DESCRIPTION
If the cache is used outside of ejs, a remove function becomes useful to invalidate a single object.