### PR TITLE
Support for Windows abs path

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -139,7 +139,7 @@ function getIncludePath(path, options) {
   var views = options.views;
 
   // Abs path
-  if (path.charAt(0) == '/') {
+  if ((path.charAt(0) == '/') || path.charAt(1) == ':') {
     includePath = exports.resolveInclude(path.replace(/^\/*/,''), options.root || '/', true);
   }
   // Relative paths


### PR DESCRIPTION
Currently, the code checks only for path being an absolute one in terms on Unix, but it misbehaves on Windows. My PR adds checking for a colon as a second character in path, so a path like this is to be treated as a an absolute path (e.g. "C:\Users\user" or "D:\project\nodejs\app").