### PR TITLE
Fix some problems with async rendering

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -905,12 +905,25 @@ exports.escapeXML = utils.escapeXML;
  * Express.js support.
  *
  * This is an alias for {@link module:ejs.renderFile}, in order to support
- * Express.js out-of-the-box.
+ * Express.js out-of-the-box. If rendered using async, a wrapper callback
+ * is passed to {@link module:ejs.renderFile} that waits until the returned
+ * promise is resolved and passes the result to Express.js
  *
  * @func
  */
 
-exports.__express = exports.renderFile;
+exports.__express = function (file, opts, callback) {
+  if (opts.async) {
+    exports.renderFile(file, opts, function (err, promise) {
+      promise.then(function (data) {
+        callback(err, data);
+      });
+    });
+  }
+  else {
+    exports.renderFile(file, opts, callback);
+  }
+};
 
 // Add require support
 /* istanbul ignore else */

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -641,7 +641,7 @@ Template.prototype = {
         e.message += ' while compiling ejs\n\n';
         e.message += 'If the above error is not helpful, you may want to try EJS-Lint:\n';
         e.message += 'https://github.com/RyanZim/EJS-Lint';
-        if (!e.async) {
+        if (!opts.async) {
           e.message += '\n';
           e.message += 'Or, if you meant to create an async function, pass async: true as an option.';
         }


### PR DESCRIPTION
* Fixed typo (`if (e.async)`) that lead to the `Or, if you meant to create an async function, pass async: true as an option.` message always being shown regardless of the `async` option.
* Fixed problem in the `__express` function where a raw Promise was being passed to express.js when `async` was enabled, instead of waiting on the Promise to resolve and passing the result to express.

Edit: If anyone is having this problem and would like to fix it, until this gets merged, use:
```js
ejs.__express = (file, options, callback) => {
	if (options.async) {
		ejs.renderFile(file, options, async (err, promise) => {
			callback(err, await promise);
		});
	}
	else {
		ejs.renderFile(file, options, callback);
	}
}
```