### PR TITLE
feat: Add support for the `with` statement in strict mode

### DIFF
--- a/docs/jsdoc/options.jsdoc
+++ b/docs/jsdoc/options.jsdoc
@@ -17,6 +17,28 @@
  * whose name is specified by {@link module:ejs.localsName} (default to
  * `locals`).
  *
+ * @property {Boolean} [strict=false]
+ * Whether to run in strict mode or not.
+ * Enforces `_with=false` unless `allowStrictWith` is set to `true`.
+ *
+ * @property {Boolean} [allowStrictWith=false]
+ * Uses a hack to use the `with () {}` construct alongside strict mode
+ * by embedding a strict function inside `with` statement, which keeps
+ * access to the runtime-augmented scope variables from the `locals` object:
+ * ```js
+ * var locals = {
+ *   foo: 'bar'
+ * }
+ *
+ * with (locals) {
+ *   (function () {
+ *     'use strict';
+ *     console.assert(typeof foo === 'string');
+ *     console.assert(foo === locals.foo);
+ *   })();
+ * }
+ * ```
+ *
  * @property {Boolean} [rmWhitespace=false]
  * Remove all safe-to-remove whitespace, including leading and trailing
  * whitespace. It also enables a safer version of `-%>` line slurping for all

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -579,7 +579,8 @@ Template.prototype = {
         prepended +=  '  with (' + opts.localsName + ' || {}) {';
         appended += '  }';
         if (opts.strict) {
-          prepended += '(function () {"use strict";';
+          prepended += opts.async ? 'await (async ' : '(';
+          prepended += 'function () {"use strict";';
           appended += ')()}';
         }
         prepended += '\n';

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -518,6 +518,7 @@ function Template(text, opts) {
   options.closeDelimiter = opts.closeDelimiter || exports.closeDelimiter || _DEFAULT_CLOSE_DELIMITER;
   options.delimiter = opts.delimiter || exports.delimiter || _DEFAULT_DELIMITER;
   options.strict = opts.strict || false;
+  options.allowStrictWith = opts.allowStrictWith || false;
   options.context = opts.context;
   options.cache = opts.cache || false;
   options.rmWhitespace = opts.rmWhitespace;
@@ -528,7 +529,7 @@ function Template(text, opts) {
   options.async = opts.async;
 
   if (options.strict) {
-    options._with = false;
+    options._with = (options.allowStrictWith && opts._with) || false;
   }
   else {
     options._with = typeof opts._with != 'undefined' ? opts._with : true;
@@ -575,8 +576,14 @@ Template.prototype = {
         prepended += '  var ' + opts.outputFunctionName + ' = __append;' + '\n';
       }
       if (opts._with !== false) {
-        prepended +=  '  with (' + opts.localsName + ' || {}) {' + '\n';
-        appended += '  }' + '\n';
+        prepended +=  '  with (' + opts.localsName + ' || {}) {';
+        appended += '  }';
+        if (opts.strict) {
+          prepended += '(function () {"use strict";';
+          appended += ')()}';
+        }
+        prepended += '\n';
+        appended += '\n';
       }
       appended += '  return __output.join("");' + '\n';
       this.source = prepended + this.source + appended;
@@ -604,7 +611,7 @@ Template.prototype = {
       }
     }
 
-    if (opts.strict) {
+    if (opts.strict && opts._with === false) {
       src = '"use strict";\n' + src;
     }
     if (opts.debug) {

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -124,10 +124,37 @@ suite('ejs.compile(str, options)', function () {
     assert.equal(ejs.render(fixture('strict.ejs'), {}, {strict: true}), 'true');
   });
 
-  test('strict mode `with` statement hack also works', function () {
+  test('strict mode `with` statement hack works', function () {
     var locals = Object.create(null);
     locals.foo = 'bar';
     assert.equal(ejs.render(fixture('strict-with.ejs'), locals, {strict: true, allowStrictWith: true, _with: true}), locals.foo);
+  });
+
+  test('strict mode `with` statement hack works in async mode', function (done) {
+    try {
+      eval('(async function() {})');
+    } catch (e) {
+      if (e instanceof SyntaxError) {
+        done();
+        return;
+      } else {
+        throw e;
+      }
+    }
+
+    var locals = Object.create(null);
+    locals.foo = 'bar';
+    ejs.render(fixture('strict-with.ejs'), locals, {
+      strict: true,
+      async: true,
+      allowStrictWith: true,
+      _with: true,
+    }).then(function (value) {
+      assert.equal(value, locals.foo);
+    }).then(
+      () => done(),
+      e => done(e)
+    );
   });
 
   test('can compile to an async function', function (done) {

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -124,6 +124,12 @@ suite('ejs.compile(str, options)', function () {
     assert.equal(ejs.render(fixture('strict.ejs'), {}, {strict: true}), 'true');
   });
 
+  test('strict mode `with` statement hack also works', function () {
+    var locals = Object.create(null);
+    locals.foo = 'bar';
+    assert.equal(ejs.render(fixture('strict-with.ejs'), locals, {strict: true, allowStrictWith: true, _with: true}), locals.foo);
+  });
+
   test('can compile to an async function', function (done) {
     try {
       eval('(async function() {})');

--- a/test/fixtures/strict-with.ejs
+++ b/test/fixtures/strict-with.ejs
@@ -1,0 +1,5 @@
+<%
+// Unspecified execution context should be `undefined` in strict mode
+var isReallyStrict = !((function () { return this; })());
+-%>
+<%= isReallyStrict && foo -%>


### PR DESCRIPTION
This makes it possible to use both the `with` statement and strict mode together by nesting a strict IIFE inside a `with` statement:
```js
with (locals) {(function () {"use strict";
	// Actually runs in strict mode
	var isReallyStrict = !((function () { return this; })());
	console.assert(isReallyStrict === true);
})()}
```

Because this is probably an ugly hack, it requires `_with`, `strict` and the new `allowStrictWith` option to all be set to `true`.