### PR TITLE
Show compiled templates in debugger

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -610,6 +610,10 @@ Template.prototype = {
     if (opts.debug) {
       console.log(src);
     }
+    if (opts.compileDebug && opts.filename) {
+      src = src + '\n'
+        + '//# sourceURL=' + opts.filename + '\n';
+    }
 
     try {
       if (opts.async) {


### PR DESCRIPTION
This commit adds a sourceURL directive to the generated template function.
This makes generated template code visible in the debugger.
See https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Debug_eval_sources

When loading templates dynamically in the browser (for example using [ejs-render-remote)](https://github.com/S2-/ejs-render-remote) this simple addition is really useful:

![firefox_80pYTdTkkL](https://user-images.githubusercontent.com/2580993/64323652-2bb06c00-cfc5-11e9-9d6a-bec47d7e0aad.png)
