### PR TITLE
feat: Add support for top‑level return

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -574,7 +574,7 @@ Template.prototype = {
       if (opts.outputFunctionName) {
         prepended += '  var ' + opts.outputFunctionName + ' = __append;' + '\n';
       }
-      appended += '  })()';
+      appended += '  }).call(this)';
       if (opts._with !== false) {
         prepended +=  '  with (' + opts.localsName + ' || {}) {';
         appended += '}';

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -574,13 +574,20 @@ Template.prototype = {
       if (opts.outputFunctionName) {
         prepended += '  var ' + opts.outputFunctionName + ' = __append;' + '\n';
       }
+      prepended +=  '  var __returned;\n';
+      prepended +=  '  ';
       appended += '  }).call(this)';
       if (opts._with !== false) {
-        prepended +=  '  with (' + opts.localsName + ' || {}) {';
+        prepended +=  'with (' + opts.localsName + ' || {}) {';
         appended += '}';
       }
-      prepended += (opts.async ? 'await (async ' : '(') + 'function () {\n';
-      appended += '\n  return __output.join("");' + '\n';
+      prepended += '__returned = ';
+      prepended += (opts.async ? 'await (async ' : '(');
+      prepended += 'function () {\n';
+      appended += '\n  if (typeof __returned !== "undefined") {\n';
+      appended += '    return __returned;\n';
+      appended += '  }\n';
+      appended += '  return __output.join("");' + '\n';
       this.source = prepended + this.source + appended;
     }
 

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -574,11 +574,13 @@ Template.prototype = {
       if (opts.outputFunctionName) {
         prepended += '  var ' + opts.outputFunctionName + ' = __append;' + '\n';
       }
+      appended += '  })()';
       if (opts._with !== false) {
-        prepended +=  '  with (' + opts.localsName + ' || {}) {' + '\n';
-        appended += '  }' + '\n';
+        prepended +=  '  with (' + opts.localsName + ' || {}) {';
+        appended += '}';
       }
-      appended += '  return __output.join("");' + '\n';
+      prepended += (opts.async ? 'await (async ' : '(') + 'function () {\n';
+      appended += '\n  return __output.join("");' + '\n';
       this.source = prepended + this.source + appended;
     }
 


### PR DESCRIPTION
This adds support for top‑level return in `ejs` files.

This makes the following pattern work correctly:

```ejs
<%
/* global foo */
if (!foo.stuff) {
	// Would previously cause a TypeError to be thrown at some point,
	// as the value returned from the EJS template would be undefined.
	return;
}

for (let s of foo.stuff) {
	%><%-s.html%><%
}
%>
```