### PR TITLE
feat: Support disabling legacy `include` preprocessor directives

### DIFF
--- a/docs/jsdoc/options.jsdoc
+++ b/docs/jsdoc/options.jsdoc
@@ -71,6 +71,14 @@
  * Whether or not to create an async function instead of a regular function.
  * This requires language support.
  *
+ * @property {boolean} [legacyInclude=true]
+ * Whether to enable legacy preprocessor include directives.
+ *
+ * **Example:**
+ * ```ejs
+ * <%- include foo %>
+ * ```
+ *
  * @static
  * @global
  */

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -526,6 +526,7 @@ function Template(text, opts) {
   options.localsName = opts.localsName || exports.localsName || _DEFAULT_LOCALS_NAME;
   options.views = opts.views;
   options.async = opts.async;
+  options.legacyInclude = typeof opts.legacyInclude != 'undefined' ? !!opts.legacyInclude : true;
 
   if (options.strict) {
     options._with = false;
@@ -711,7 +712,7 @@ Template.prototype = {
           }
         }
         // HACK: backward-compat `include` preprocessor directives
-        if ((include = line.match(/^\s*include\s+(\S+)/))) {
+        if (opts.legacyInclude && (include = line.match(/^\s*include\s+(\S+)/))) {
           opening = matches[index - 1];
           // Must be in EVAL or RAW mode
           if (opening && (opening == o + d || opening == o + d + '-' || opening == o + d + '_')) {


### PR DESCRIPTION
[KumaScript](https://github.com/mdn/kumascript) and other modern EJS‑using projects doesn’t need this, so it just slows down template compilation time where the EJS compiler tries to find `include` directives.