### PR TITLE
fix: Correct error message when `async != true`

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -658,9 +658,9 @@ Template.prototype = {
         e.message += ' while compiling ejs\n\n';
         e.message += 'If the above error is not helpful, you may want to try EJS-Lint:\n';
         e.message += 'https://github.com/RyanZim/EJS-Lint';
-        if (!e.async) {
+        if (!opts.async) {
           e.message += '\n';
-          e.message += 'Or, if you meant to create an async function, pass async: true as an option.';
+          e.message += 'Or, if you meant to create an async function, pass `async: true` as an option.';
         }
       }
       throw e;

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -183,6 +183,32 @@ suite('ejs.compile(str, options)', function () {
       done();
     });
   });
+
+  test('Non-async error message mentions `async: true`', function (done) {
+    try {
+      eval('(async function() {})');
+    } catch (e) {
+      if (e instanceof SyntaxError) {
+        done();
+        return;
+      } else {
+        throw e;
+      }
+    }
+
+    try {
+      ejs.compile('<%= await "Hi" %>');
+    }
+    catch (err) {
+      if (err instanceof SyntaxError) {
+        assert.ok(err.message.indexOf('async: true') > -1);
+        return done();
+      } else {
+        throw err;
+      }
+    }
+    throw new Error('no error reported when there should be');
+  });
 });
 
 suite('client mode', function () {


### PR DESCRIPTION
Currently, `ejs.compile('<%= await foo() %>')` won't say anything about needing to pass `async: true`.