### PR TITLE
chore(travis): Add Node 0.10 and Node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 sudo: false
 node_js:
+  - "0.10"
+  - "0.12"
   - "4"
   - "6"
   - "8"


### PR DESCRIPTION
This runs the tests on **Node 0.10** and **Node 0.12**, which are the oldest **EJS**‑supported **Node** releases, according to `package.json`: https://github.com/mde/ejs/blob/c600a788b7f31b6f0bfd269055bd7b266c97c5ac/package.json#L34-L36