### PR TITLE
feat: Set compiled function name

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -666,15 +666,10 @@ Template.prototype = {
       throw e;
     }
 
-    if (opts.client) {
-      fn.dependencies = this.dependencies;
-      return fn;
-    }
-
     // Return a callable function which will execute the function
     // created by the source-code, with the passed data as locals
     // Adds a local `include` function which allows full recursive include
-    var returnedFn = function (data) {
+    var returnedFn = opts.client ? fn : function anonymous(data) {
       var include = function (path, includeData) {
         var d = utils.shallowCopy({}, data);
         if (includeData) {
@@ -685,6 +680,18 @@ Template.prototype = {
       return fn.apply(opts.context, [data || {}, escapeFn, include, rethrow]);
     };
     returnedFn.dependencies = this.dependencies;
+    if (opts.filename && typeof Object.defineProperty === 'function') {
+      var filename = opts.filename;
+      var basename = path.basename(filename, path.extname(filename));
+      try {
+        Object.defineProperty(returnedFn, 'name', {
+          value: basename,
+          writable: false,
+          enumerable: false,
+          configurable: true
+        });
+      } catch (e) {/* ignore */}
+    }
     return returnedFn;
   },
 

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -209,6 +209,24 @@ suite('ejs.compile(str, options)', function () {
     }
     throw new Error('no error reported when there should be');
   });
+
+  var testFuncName = typeof Object.defineProperty === 'function' ? test : test.skip;
+
+  testFuncName('Compiled function name matches `filename` without the extension', function (done) {
+    var func = ejs.compile('<%= "Foo" %>', {
+      filename: 'foo.ejs'
+    });
+
+    assert.ok(func.name === 'foo');
+    return done();
+  });
+
+  testFuncName('Compiled function name defaults to "anonymous" when `filename` is unspecified', function (done) {
+    var func = ejs.compile('<%= "Foo" %>');
+
+    assert.ok(func.name === 'anonymous');
+    return done();
+  });
 });
 
 suite('client mode', function () {


### PR DESCRIPTION
This sets the `name` property for the compiled function, so that it matches `opts.filename` without the file extension.

I also made it so that the default name would be `anonymous` instead of `returnedFn`, to match what the `Function` constructor sets the `name` to.