### PR TITLE
Explain how to use ES6 features and documents the beautify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Therefore, we do not recommend using this shortcut.
     output inside scriptlet tags.
   - `async`                 When `true`, EJS will use an async function for rendering. (Depends
     on async/await support in the JS runtime.
+  - `beautify`              Make sure to set this to 'false' in order to skip UglifyJS parsing,
+    when using ES6 features (`const`, etc) as UglifyJS doesn't understand them.
 
 This project uses [JSDoc](http://usejsdoc.org/). For the full public API
 documentation, clone the repository and run `npm run doc`. This will run JSDoc


### PR DESCRIPTION
The `beautify` option documentation was missing.

It took me hours until I could figure out why I wasn't able to use ES6 features with EJS, using this loader. Hopefully this should make it easier for others to use this loader to compile EJS templates with ES6 features.

Thanks for considering the patch and for this loader.

Best,
Rodrigo.