### PR TITLE
Feat/ Support array of 'root' directories to include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ coverage/
 /ejs.min.js
 out/
 pkg/
+/package-lock.json

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Therefore, we do not recommend using this shortcut.
     are using `renderFile()`. Used by `cache` to key caches, and for includes.
   - `root`                  Set project root for includes with an absolute path (/file.ejs).
     Can be array to try to resolve include from multiple directories.
+  - `views`                 An array of paths that EJS can look in to attempt to resolve
+    includes with relative paths.
   - `context`               Function execution context
   - `compileDebug`          When `false` no debug instrumentation is compiled
   - `client`                When `true`, compiles a function that can be rendered

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Therefore, we do not recommend using this shortcut.
   - `filename`              The name of the file being rendered. Not required if you
     are using `renderFile()`. Used by `cache` to key caches, and for includes.
   - `root`                  Set project root for includes with an absolute path (/file.ejs).
+    Can be array to try to resolve include from multiple directories.
   - `context`               Function execution context
   - `compileDebug`          When `false` no debug instrumentation is compiled
   - `client`                When `true`, compiles a function that can be rendered

--- a/examples/hello.ejs
+++ b/examples/hello.ejs
@@ -1,0 +1,1 @@
+<span>Hello EJS!</span>

--- a/examples/output-function.ejs
+++ b/examples/output-function.ejs
@@ -1,4 +1,5 @@
 <ul>
+<%- include('/hello.ejs') %>
 <%
     users.forEach(function (user) {
         echo('<li>');

--- a/examples/output-function.js
+++ b/examples/output-function.js
@@ -15,6 +15,7 @@ var data = {
 };
 
 var ret = ejs.compile(read(path, 'utf8'), {
+  root: [join(__dirname, '..'), __dirname],
   filename: path,
   outputFunctionName: 'echo'
 })(data);

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -128,6 +128,23 @@ exports.resolveInclude = function(name, filename, isDir) {
 };
 
 /**
+ * Try to resolve file path on multiple directories
+ *
+ * @param  {String}        name  specified path
+ * @param  {Array<String>} paths list of possible parent directory paths
+ * @return {String}
+ */
+function resolvePaths(name, paths) {
+  var filePath
+  if (paths.some(function (v) {
+    filePath = exports.resolveInclude(name, v, true)
+    return fs.existsSync(filePath)
+  })) {
+    return filePath
+  }
+}
+
+/**
  * Get the path to the included file by Options
  *
  * @param  {String}  path    specified path
@@ -140,21 +157,11 @@ function getIncludePath(path, options) {
   var views = options.views;
   var match = /^[A-Za-z]+:\\|^\//.exec(path);
 
-  // Try to resolve on multiple directories
-  var tryPathsList = function(paths) {
-    if (paths.some(function (v) {
-      filePath = exports.resolveInclude(path, v, true);
-      return fs.existsSync(filePath);
-    })) {
-      includePath = filePath;
-    }
-  }
-
   // Abs path
   if (match && match.length) {
     path = path.replace(/^\/*/, '');
     if (Array.isArray(options.root)) {
-      tryPathsList(options.root);
+      includePath = resolvePaths(path, options.root);
     } else {
       includePath = exports.resolveInclude(path, options.root || '/', true);
     }
@@ -170,7 +177,7 @@ function getIncludePath(path, options) {
     }
     // Then look in any views directories
     if (!includePath && Array.isArray(views)) {
-      tryPathsList(views);
+      includePath = resolvePaths(path, views);
     }
     if (!includePath) {
       throw new Error('Could not find the include file "' +

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -140,9 +140,24 @@ function getIncludePath(path, options) {
   var views = options.views;
   var match = /^[A-Za-z]+:\\|^\//.exec(path);
 
+  // Try to resolve on multiple directories
+  var tryPathsList = function(paths) {
+    if (paths.some(function (v) {
+      filePath = exports.resolveInclude(path, v, true);
+      return fs.existsSync(filePath);
+    })) {
+      includePath = filePath;
+    }
+  }
+
   // Abs path
   if (match && match.length) {
-    includePath = exports.resolveInclude(path.replace(/^\/*/,''), options.root || '/', true);
+    path = path.replace(/^\/*/, '');
+    if (Array.isArray(options.root)) {
+      tryPathsList(options.root);
+    } else {
+      includePath = exports.resolveInclude(path, options.root || '/', true);
+    }
   }
   // Relative paths
   else {
@@ -154,13 +169,8 @@ function getIncludePath(path, options) {
       }
     }
     // Then look in any views directories
-    if (!includePath) {
-      if (Array.isArray(views) && views.some(function (v) {
-        filePath = exports.resolveInclude(path, v, true);
-        return fs.existsSync(filePath);
-      })) {
-        includePath = filePath;
-      }
+    if (!includePath && Array.isArray(views)) {
+      tryPathsList(views);
     }
     if (!includePath) {
       throw new Error('Could not find the include file "' +


### PR DESCRIPTION
I've purposed implementing an `includer` function passed through options (https://github.com/mde/ejs/issues/500), but now I realized that EJS already supports array of `views` paths (not documented ?), it makes easy to add support for `root` array to handle includes with absolute path from multiple directories :relaxed: 

Although not as flexible as an `includer` function, this should be enough for my case and may require fewer changes to the lib, so I'm suggesting it first.

Anyway, I still available to try https://github.com/mde/ejs/issues/500 if it’s still a good idea, wdyt @mde ?