### PR TITLE
docs: Fix simple typo, preceeding -> preceding

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -14,7 +14,7 @@ Table of contents
   - `<%-`: Unescaped output
   - `<%#`: Comments
   - `<%`: Scriptlet
-  - `<%_`: Scriptlet, removes all preceeding whitespace
+  - `<%_`: Scriptlet, removes all preceding whitespace
 - Ending tags
   - `%>`: Regular ending tag
   - `-%>`: Removes trailing newline


### PR DESCRIPTION
There is a small typo in docs/syntax.md.

Should read `preceding` rather than `preceeding`.

