### PR TITLE
CI/ Create release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,34 @@
+name: Create release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get semver number
+        id: get_semver
+        env:
+          TAG_NAME: ${{ github.ref }}
+        run: echo "::set-output name=num::${TAG_NAME:11}"
+
+      - name: Create release on GitHub API
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: "v${{ steps.get_semver.outputs.num }}"
+          body: |
+            Version ${{ steps.get_semver.outputs.num }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
Automatically create GitHub release when new version tag is created, it's specially useful to notify GitHub users subscribed on repo to _Watch releases_.