### PR TITLE
Fix cli includes

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -148,6 +148,9 @@ function run() {
     }
   }
 
+  // Default to having views relative from the current working directory
+  opts.views = ['.'];
+
   // Ensure there's a template to render
   if (!templatePath) {
     throw new Error('Please provide a template path. (Run ejs -h for help)');


### PR DESCRIPTION
Includes don't currently work with the cli (see https://github.com/mde/ejs/issues/521), this fixes the problem by specifying the current working directory as a default view.