### PR TITLE
Fix cli passthrough options

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -23,6 +23,7 @@ delete global.jake; // NO NOT WANT
 program.setTaskNames = function (n) { this.taskNames = n; };
 
 let ejs = require('../lib/ejs');
+let { hyphenToCamel } = require('../lib/utils');
 let fs = require('fs');
 let args = process.argv.slice(2);
 let usage = fs.readFileSync(`${__dirname}/../usage.txt`).toString();
@@ -126,7 +127,7 @@ function run() {
   let pOpts = {};
 
   for (let p in program.opts) {
-    let name = p.replace(/-[a-z]/g, (match) => { return match[1].toUpperCase(); });
+    let name = hyphenToCamel(p);
     pOpts[name] = program.opts[p];
   }
 
@@ -135,7 +136,7 @@ function run() {
 
   // Same-named 'passthrough' opts
   CLI_OPTS.forEach((opt) => {
-    let optName = opt.full;
+    let optName = hyphenToCamel(opt.full);
     if (opt.passThrough && typeof pOpts[optName] != 'undefined') {
       opts[optName] = pOpts[optName];
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -165,3 +165,15 @@ exports.cache = {
     this._data = {};
   }
 };
+
+/**
+ * Transforms hyphen case variable into camel case.
+ *
+ * @param {String} string Hyphen case string
+ * @return {String} Camel case string
+ * @static
+ * @private
+ */
+exports.hyphenToCamel = function (str) {
+  return str.replace(/-[a-z]/g, (match) => { return match[1].toUpperCase(); });
+}

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,4 +1,5 @@
 let exec = require('child_process').execSync;
+let fs = require('fs');
 let assert = require('assert');
 
 function run(cmd) {
@@ -29,6 +30,11 @@ suite('cli', function () {
   test('rendering, custom delimiter, passed data overrides file', function () {
     let o = run('./bin/cli.js -m $ -f ./test/fixtures/user_data.json ./test/fixtures/user.ejs name=frang');
     assert.equal(o, '<h1>frang</h1>\n');
+  });
+
+  test('rendering, remove whitespace option (hyphen case)', function () {
+    let o = run('./bin/cli.js --rm-whitespace ./test/fixtures/rmWhitespace.ejs');
+    assert.equal(o, fs.readFileSync('test/fixtures/rmWhitespace.html', 'utf-8'));
   });
 
 });


### PR DESCRIPTION
Passthrough hyphen case cli options (open-delimeter, close-delimeter, rm-whitespace, etc.) were getting parsed as `pOpts['camelCase']` but later fetched as `opts['hyphen-case'] = pOpts['hyphen-case']` (`opts` is later used in `ejs.render()`). This would lose any hyphen case options as `pOpts['rm-whitespace']` would be undefined but `pOpts['rmWhitespace']` would be what you really needed.