### PR TITLE
Add template dependencies for newest include method

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -322,6 +322,33 @@ function includeFile(path, options) {
 }
 
 /**
+ * Get the JavaScript source of an included file.
+ *
+ * @memberof module:ejs-internal
+ * @param {String}  path    path for the specified file
+ * @param {Options} options compilation options
+ * @return {Object}
+ * @static
+ */
+
+function includeSource(path, options) {
+  var opts = utils.shallowCopy({}, options);
+  var includePath;
+  var template;
+  includePath = getIncludePath(path, opts);
+  template = fileLoader(includePath).toString().replace(_BOM, '');
+  opts.filename = includePath;
+  var templ = new Template(template, opts);
+  templ.generateSource();
+  return {
+    source: templ.source,
+    filename: includePath,
+    template: template,
+    dependencies: templ.dependencies
+  };
+}
+
+/**
  * Re-throw the given `err` in context to the `str` of ejs, `filename`, and
  * `lineno`.
  *
@@ -504,6 +531,14 @@ exports.clearCache = function () {
   exports.cache.reset();
 };
 
+function onlyUnique(value, index, self) {
+  return self.indexOf(value) === index;
+}
+
+function uniq(array) {
+  return array.filter(onlyUnique);
+}
+
 function Template(text, opts) {
   opts = opts || {};
   var options = {};
@@ -513,6 +548,7 @@ function Template(text, opts) {
   this.truncate = false;
   this.currentLine = 1;
   this.source = '';
+  this.dependencies = [];
   options.client = opts.client || false;
   options.escapeFunction = opts.escape || opts.escapeFunction || utils.escapeXML;
   options.compileDebug = opts.compileDebug !== false;
@@ -533,6 +569,7 @@ function Template(text, opts) {
   options.async = opts.async;
   options.destructuredLocals = opts.destructuredLocals;
   options.legacyInclude = typeof opts.legacyInclude != 'undefined' ? !!opts.legacyInclude : true;
+  options.trackDependencies = opts.trackDependencies || false;
 
   if (options.strict) {
     options._with = false;
@@ -690,6 +727,7 @@ Template.prototype = {
       };
       return fn.apply(opts.context, [data || {}, escapeFn, include, rethrow]);
     };
+    returnedFn.dependencies = uniq(this.dependencies);
     if (opts.filename && typeof Object.defineProperty === 'function') {
       var filename = opts.filename;
       var basename = path.basename(filename, path.extname(filename));
@@ -728,6 +766,9 @@ Template.prototype = {
     if (matches && matches.length) {
       matches.forEach(function (line, index) {
         var closing;
+        var include;
+        var includeOpts;
+        var includeObj;
         // If this is an opening tag, check for closing tags
         // FIXME: May end up with some false positives here
         // Better to store modes as k/v with openDelimiter + delimiter as key
@@ -737,6 +778,19 @@ Template.prototype = {
           closing = matches[index + 2];
           if (!(closing == d + c || closing == '-' + d + c || closing == '_' + d + c)) {
             throw new Error('Could not find matching close tag for "' + line + '".');
+          }
+        }
+        if (self.opts.trackDependencies) {
+          include = line.match(/^\s*include\(\s*['"](\S+)['"].*\)/);
+          if (include) {
+            includeOpts = utils.shallowCopy({}, self.opts);
+            includeObj = includeSource(include[1], includeOpts);
+            self.dependencies.push(
+              exports.resolveInclude(include[1], includeOpts.filename)
+            );
+            includeObj.dependencies.forEach(function(dep) {
+              self.dependencies.push(dep);
+            });
           }
         }
         self.scanLine(line);

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -1107,6 +1107,26 @@ suite('include()', function () {
 
 });
 
+suite('transitive dependency', function () {
+  test('tracks transitive dependency correctly - with parenthesis', function () {
+    var file = 'test/fixtures/track-dependencies-with-parenthesis.ejs';
+    var fn = ejs.compile(fixture('track-dependencies-with-parenthesis.ejs'), { filename: file, trackDependencies: true });
+    // only 2 dependencies : simple.ejs and simple-with-parenthesis.ejs
+    assert.equal(fn.dependencies.length, 2);
+    assert.ok(fn.dependencies.indexOf(__dirname + '/fixtures/includes/simple.ejs') > -1);
+    assert.ok(fn.dependencies.indexOf(__dirname + '/fixtures/includes/simple-with-parenthesis.ejs') > -1);
+  });
+
+  test('tracks transitive dependency correctly - without duplicates', function () {
+    var file = 'test/fixtures/track-dependencies-without-duplicates.ejs';
+    var fn = ejs.compile(fixture('track-dependencies-without-duplicates.ejs'), { filename: file, trackDependencies: true });
+    // only 2 dependencies : simple.ejs and simple-with-parenthesis.ejs
+    assert.equal(fn.dependencies.length, 2);
+    assert.ok(fn.dependencies.indexOf(__dirname + '/fixtures/includes/simple.ejs') > -1);
+    assert.ok(fn.dependencies.indexOf(__dirname + '/fixtures/includes/simple-with-parenthesis.ejs') > -1);
+  });
+});
+
 suite('comments', function () {
   test('fully render with comments removed', function () {
     assert.equal(ejs.render(fixture('comments.ejs')),

--- a/test/fixtures/includes/simple-with-parenthesis.ejs
+++ b/test/fixtures/includes/simple-with-parenthesis.ejs
@@ -1,0 +1,2 @@
+This is 'simple-with-parenthesis' template.
+<% include('simple') %>

--- a/test/fixtures/includes/simple.ejs
+++ b/test/fixtures/includes/simple.ejs
@@ -1,0 +1,1 @@
+This is 'simple' template.

--- a/test/fixtures/track-dependencies-with-parenthesis.ejs
+++ b/test/fixtures/track-dependencies-with-parenthesis.ejs
@@ -1,0 +1,1 @@
+<% include('includes/simple-with-parenthesis') -%>

--- a/test/fixtures/track-dependencies-without-duplicates.ejs
+++ b/test/fixtures/track-dependencies-without-duplicates.ejs
@@ -1,0 +1,3 @@
+<% include('includes/simple-with-parenthesis') -%>
+<% include('includes/simple-with-parenthesis') -%>
+<% include('includes/simple-with-parenthesis') -%>


### PR DESCRIPTION
In the spirit of pull request #428, here is an update one that update code to latest EJS version (the one without legacy include).
It is opt-in, it can be activate in very specific scenario.
With this PR, Tracking dependencies still needs to recursively generate template, it needs a better solution. In the meantime it can acts as a base for talking about it =)