### PR TITLE
feat: add a defence for Arbitrary Code Injection

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -636,7 +636,7 @@ Template.prototype = {
     }
     if (opts.compileDebug && opts.filename) {
       src = src + '\n'
-        + '//# sourceURL=' + opts.filename + '\n';
+        + '//# sourceURL=' + opts.filename.replace(/[\r\n]/g, "") + '\n';
     }
 
     try {


### PR DESCRIPTION
add a defence for Arbitrary Code Injection in some situation, according to https://snyk.io/vuln/SNYK-JS-EJS-1049328 , e.g:

let ejs = require('ejs');
ejs.render('./views/test.ejs',{
    filename:'/etc/passwd\nfinally { this.global.process.mainModule.require(\'child_process\').execSync(\'touch EJS_HACKED\') }',
    compileDebug: true
})

or 

let ejs = require('ejs');
ejs.render('./views/test.ejs',{
    filename:'/etc/passwd\nfinally { this.global.process.mainModule.require(\'child_process\').execSync(\'touch EJS_HACKED\') }'
})