### PR TITLE
Backport fix code injection

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -628,7 +628,7 @@ Template.prototype = {
     }
     if (opts.compileDebug && opts.filename) {
       src = src + '\n'
-        + '//# sourceURL=' + sanitizedFilename + '\n';
+        + '//# sourceURL=' + encodeURI(opts.filename) + '\n';
     }
 
     try {

--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -569,6 +569,8 @@ Template.prototype = {
     var appended = '';
     var escapeFn = opts.escapeFunction;
     var ctor;
+    /** @type {string} */
+    var sanitizedFilename = opts.filename ? JSON.stringify(opts.filename) : 'undefined';
 
     if (!this.source) {
       this.generateSource();
@@ -600,8 +602,7 @@ Template.prototype = {
     if (opts.compileDebug) {
       src = 'var __line = 1' + '\n'
         + '  , __lines = ' + JSON.stringify(this.templateText) + '\n'
-        + '  , __filename = ' + (opts.filename ?
-        JSON.stringify(opts.filename) : 'undefined') + ';' + '\n'
+        + '  , __filename = ' + sanitizedFilename + ';' + '\n'
         + 'try {' + '\n'
         + this.source
         + '} catch (e) {' + '\n'
@@ -627,7 +628,7 @@ Template.prototype = {
     }
     if (opts.compileDebug && opts.filename) {
       src = src + '\n'
-        + '//# sourceURL=' + opts.filename + '\n';
+        + '//# sourceURL=' + sanitizedFilename + '\n';
     }
 
     try {


### PR DESCRIPTION
backported fix for code injection (#571 and abaee2be937236b1b8da9a1f55096c17dda905fd) to the 2.x branch of ejs.

As this branch contains lot less dependencies it is the better choice for browser-side integration as long as there is no extra ejs-cli package. And all other dependencies of the 2.x branch are up to date (regarding security problems), therefor its safe to use.

Please merge this and publish a new version 2.7.5 to npm.

Many Thanks in advance,
Stefan Seide