### PR TITLE
fixed some situations where 'rethrow' might throw internal errors.

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -332,24 +332,25 @@ function includeFile(path, options) {
  * @param {String} flnm     file name of the EJS file
  * @param {Number} lineno   line number of the error
  * @param {EscapeCallback} esc
+ * @throws {Error} usually 'err' if truthy. A new error instance otherwise.
  * @static
  */
-
 function rethrow(err, str, flnm, lineno, esc) {
+  str = str || '';
+
   var lines = str.split('\n');
   var start = Math.max(lineno - 3, 0);
   var end = Math.min(lines.length, lineno + 3);
-  var filename = esc(flnm);
+  var filename = esc ? esc(flnm) : flnm;
   // Error context
-  var context = lines.slice(start, end).map(function (line, i){
+  var context = lines.slice(start, end).map(function (line, i) {
     var curr = i + start + 1;
     return (curr == lineno ? ' >> ' : '    ')
-      + curr
-      + '| '
-      + line;
+      + curr + '| ' + line;
   }).join('\n');
 
   // Alter exception message
+  err = err || new Error('Internal: Missing \'error\' instance for rewrite.');
   err.path = filename;
   err.message = (filename || 'ejs') + ':'
     + lineno + '\n'
@@ -358,6 +359,10 @@ function rethrow(err, str, flnm, lineno, esc) {
 
   throw err;
 }
+
+// export 'rethrow' for testing purposes
+exports.rethrowError = rethrow;
+
 
 function stripSemi(str){
   return str.replace(/;(\s*$)/, '$1');

--- a/test/ejs.rethrow.js
+++ b/test/ejs.rethrow.js
@@ -1,0 +1,135 @@
+/* jshint mocha: true */
+/* eslint-env node, mocha */
+
+/**
+ * Module dependencies.
+ */
+
+var assert = require('assert');
+var ejs = require('../lib/ejs');
+
+/**
+ *  Make sure ejs exports all it is expected to export...
+ */
+suite('unit testing for completeness of module \'ejs.js\' exports', function () {
+  test('expect \'rethrowError\' to be exported', function () {
+    assert.ok(typeof(ejs.rethrowError)==='function');
+  });
+});
+
+suite('unit testing exported function \'rethrowError\' of module \'ejs.js\'', function () {
+  test('it should always throw: without parameters', function () {
+    // TODO: Shouldn't 'Error: ejs:undefined' better point to: 'Error: ejs:0' or 'Error: ejs:[?]>'?
+    const err = { name: 'Error' };
+    assert.throws(() => { ejs.rethrowError(); }, err );
+    try { ejs.rethrowError(); }
+    catch( e ) {
+      const errstr = 'Error: ejs:undefined\n\n\nInternal: Missing \'error\' instance for rewrite.';
+      // console.dir( e.toString());
+      assert.ok( e.toString() === errstr );
+    }
+  });
+  test('it should always throw: with parameter \'err\' {Error}', function () {
+    const err = { name: 'Error' };
+    assert.throws(() => { ejs.rethrowError(new Error('Out of fun.')); }, err );
+    try { ejs.rethrowError(new Error('Out of fun.')); }
+    catch( e ) {
+      const errstr = 'Error: ejs:undefined\n\n\nOut of fun.';
+      // console.dir( e.toString());
+      assert.ok( e.toString() === errstr );
+    }
+  });
+  test('it should always throw: with parameters \'err\' {Error}, \'str\' {string} and \'lineno\' {undefined}', function () {
+    // TODO: Shouldn't we have defaults in a way, that 'str' is handled even if lineno is not given?
+    // See: 'str' is ignored completely in resulting error message.
+    const err = { name: 'Error' };
+    const str = 'some line (0)\nsome other line(1)';
+    assert.throws(() => { ejs.rethrowError(new Error('Out of fun.'), str); }, err );
+    try { ejs.rethrowError(new Error('Out of fun.'), str); }
+    catch( e ) {
+      const errstr = 'Error: ejs:undefined\n\n\nOut of fun.';
+      // console.dir( e.toString());
+      assert.ok( e.toString() === errstr );
+    }
+  });
+  test('it should always throw: with parameters \'err\' {Error}, \'str\' {string} and \'lineno\' {0}', function () {
+    const err = { name: 'Error' };
+    const str = 'some line (0)\nsome other line(1)';
+    const flnm = 'filename.js';
+    const lineno = 0;
+    assert.throws(() => { ejs.rethrowError(new Error('Out of fun.'), str, flnm, lineno); }, err );
+    try { ejs.rethrowError(new Error('Out of fun.'), str, flnm, lineno); }
+    catch( e ) {
+      const errstr = 'Error: filename.js:0\n    1| some line (0)\n    2| some other line(1)\n\nOut of fun.';
+      // console.dir( e.toString());
+      assert.ok( e.toString() === errstr );
+    }
+  });
+  test('it should always throw: with parameters \'err\' {Error}, \'str\' {string} and \'lineno\' {1}', function () {
+    const err = { name: 'Error' };
+    const str = 'some line (0)\nsome other line(1)';
+    const flnm = 'filename.js';
+    const lineno = 1;
+    assert.throws(() => { ejs.rethrowError(new Error('Out of fun.'), str, flnm, lineno); }, err );
+    try { ejs.rethrowError(new Error('Out of fun.'), str, flnm, lineno); }
+    catch( e ) {
+      const errstr = 'Error: filename.js:1\n >> 1| some line (0)\n    2| some other line(1)\n\nOut of fun.';
+      // console.dir( e.toString());
+      assert.ok( e.toString() === errstr );
+    }
+  });
+  test('it should always throw: with parameters \'err\' {Error}, \'str\' {string} and \'lineno\' {2}', function () {
+    const err = { name: 'Error' };
+    const str = 'some line (0)\nsome other line(1)';
+    const flnm = 'filename.js';
+    const lineno = 2;
+    assert.throws(() => { ejs.rethrowError(new Error('Out of fun.'), str, flnm, lineno); }, err );
+    try { ejs.rethrowError(new Error('Out of fun.'), str, flnm, lineno); }
+    catch( e ) {
+      const errstr = 'Error: filename.js:2\n    1| some line (0)\n >> 2| some other line(1)\n\nOut of fun.';
+      // console.dir( e.toString());
+      assert.ok( e.toString() === errstr );
+    }
+  });
+  test('it should always throw: with parameters \'err\' {Error}, \'str\' {string} and \'lineno\' {3}', function () {
+    const err = { name: 'Error' };
+    const str = 'some line (0)\nsome other line(1)';
+    const flnm = 'filename.js';
+    const lineno = 3;
+    assert.throws(() => { ejs.rethrowError(new Error('Out of fun.'), str, flnm, lineno); }, err );
+    try { ejs.rethrowError(new Error('Out of fun.'), str, flnm, lineno); }
+    catch( e ) {
+      const errstr = 'Error: filename.js:3\n    1| some line (0)\n    2| some other line(1)\n\nOut of fun.';
+      // console.dir( e.toString());
+      assert.ok( e.toString() === errstr );
+    }
+  });
+  test('it should always throw: with parameters \'err\' {Error}, \'str\' {string}, \'lineno\' {undefined} and \'esc\' {function}', function () {
+    const err = { name: 'Error' };
+    const str = 'some line (0)\nsome other line(1)';
+    const flnm = 'filename.js';
+    const lineno = undefined;
+    const esc = (x) => { return 'foo' + x; };
+    assert.throws(() => { ejs.rethrowError(new Error('Out of fun.'), str, flnm, lineno, esc); }, err );
+    try { ejs.rethrowError(new Error('Out of fun.'), str, flnm, lineno, esc); }
+    catch( e ) {
+      const errstr = 'Error: foofilename.js:undefined\n\n\nOut of fun.';
+      // console.dir( e.toString());
+      assert.ok( e.toString() === errstr );
+    }
+  });
+  test('it should always throw: with parameters \'err\' {Error}, \'str\' {string}, \'lineno\' {0} and \'esc\' {function}', function () {
+    const err = { name: 'Error' };
+    const str = 'some line (0)\nsome other line(1)';
+    const flnm = 'filename.js';
+    const lineno = 0;
+    const esc = (x) => { return 'foo' + x; };
+    assert.throws(() => { ejs.rethrowError(new Error('Out of fun.'), str, flnm, lineno, esc); }, err );
+    try { ejs.rethrowError(new Error('Out of fun.'), str, flnm, lineno, esc); }
+    catch( e ) {
+      const errstr = 'Error: foofilename.js:0\n    1| some line (0)\n    2| some other line(1)\n\nOut of fun.';
+      // console.dir( e.toString());
+      assert.ok( e.toString() === errstr );
+    }
+  });
+});


### PR DESCRIPTION
Parameters 'err', 'str' and 'esc' should never be null|undefined elsewise there will not be a rethrow but a throwing of an internal error.

Probably it might be a good idea to set <code>lineno = lineno || 0;</code> to get a consistent error message if str exists and is not empty. See errstring in tests 3 and 4 (suite 2) (index human based 1). Search "TODO" in tests.

Maybe it would be useful to enhance the errormessage of test 1 (suite 2). Editors can handle filename:0 but fail with filename:undefined. Search "TODO" in tests.

What's your point of view? I'd change and update the pull request if you agree.