### PR TITLE
test: fix hyphenToCamel assertion

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -231,9 +231,8 @@ suite('unit testing exported functions of module \'utils.js\'', function () {
    *  Unit testing of exported function 'hyphenToCamel'
    */
   suite('unit testing function \'hyphenToCamel\' of module \'utils.js\'', function () {
-    test('it should be callable without parameters', function () {
-      const message = 'Cannot read property \'replace\' of undefined';
-      assert.throws(() => { utils.hyphenToCamel(); }, { name: 'TypeError', message });
+    test('it should not be callable without parameters', function () {
+      assert.throws(() => { utils.hyphenToCamel(); }, { name: 'TypeError' });
     });
     test('it should be callable with parameter \'str\' {string}', function () {
       const str = 'some string';


### PR DESCRIPTION
The error message changes depending on the version of Node.js, this makes it so that just the error name is asserted rather than a brittle message. Also the test description was incorrect.