### PR TITLE
add <%& raw mode equals <%-

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -57,7 +57,7 @@ var _DEFAULT_CLOSE_DELIMITER = '>';
 var _DEFAULT_DELIMITER = '%';
 var _DEFAULT_LOCALS_NAME = 'locals';
 var _NAME = 'ejs';
-var _REGEX_STRING = '(<%%|%%>|<%=|<%-|<%_|<%#|<%|%>|-%>|_%>)';
+var _REGEX_STRING = '(<%%|%%>|<%=|<%&|<%-|<%_|<%#|<%|%>|-%>|_%>)';
 var _OPTS_PASSABLE_WITH_DATA = ['delimiter', 'scope', 'context', 'debug', 'compileDebug',
   'client', '_with', 'rmWhitespace', 'strict', 'filename', 'async'];
 // We don't allow 'cache' option to be passed in the data obj for
@@ -828,6 +828,9 @@ Template.prototype = {
       break;
     case o + d + '=':
       this.mode = Template.modes.ESCAPED;
+      break;
+    case o + d + '&':
+      this.mode = Template.modes.RAW;
       break;
     case o + d + '-':
       this.mode = Template.modes.RAW;


### PR DESCRIPTION
add this feature because prettier.js formatter auto change <%- to <% -, 

any other solutions for this, prettier.js HTML formatter is useful. I don't know how to fixed it to compatible ejs, so I change ejs syntax compatible with ejs