### PR TITLE
Fix potential security issue caused by Prototype Pollution

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -65,7 +65,6 @@ var _OPTS_PASSABLE_WITH_DATA = ['delimiter', 'scope', 'context', 'debug', 'compi
 // so we make an exception for `renderFile`
 var _OPTS_PASSABLE_WITH_DATA_EXPRESS = _OPTS_PASSABLE_WITH_DATA.concat('cache');
 var _BOM = /^\uFEFF/;
-var _JS_IDENTIFIER = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/;
 
 /**
  * EJS template function cache. This can be a LRU object from lru-cache NPM
@@ -228,7 +227,7 @@ function handleCache(options, template) {
     // istanbul ignore if: should not happen at all
     if (!filename) {
       throw new Error('Internal EJS error: no file name or template '
-                    + 'provided');
+          + 'provided');
     }
     template = fileLoader(filename).toString().replace(_BOM, '');
   }
@@ -346,17 +345,17 @@ function rethrow(err, str, flnm, lineno, esc) {
   var context = lines.slice(start, end).map(function (line, i){
     var curr = i + start + 1;
     return (curr == lineno ? ' >> ' : '    ')
-      + curr
-      + '| '
-      + line;
+        + curr
+        + '| '
+        + line;
   }).join('\n');
 
   // Alter exception message
   err.path = filename;
   err.message = (filename || 'ejs') + ':'
-    + lineno + '\n'
-    + context + '\n\n'
-    + err.message;
+      + lineno + '\n'
+      + context + '\n\n'
+      + err.message;
 
   throw err;
 }
@@ -506,8 +505,18 @@ exports.clearCache = function () {
   exports.cache.reset();
 };
 
+function SetOwnProperty(opts){
+  for(let key in opts){
+    if(!opts.hasOwnProperty(key)){
+      opts[key] = undefined;
+    }
+  }
+  return opts;
+}
+
 function Template(text, opts) {
   opts = opts || utils.createNullProtoObjWherePossible();
+  opts = SetOwnProperty(opts);
   var options = utils.createNullProtoObjWherePossible();
   this.templateText = text;
   /** @type {string | null} */
@@ -563,8 +572,8 @@ Template.prototype = {
     var open = utils.escapeRegExpChars(this.opts.openDelimiter);
     var close = utils.escapeRegExpChars(this.opts.closeDelimiter);
     str = str.replace(/%/g, delim)
-      .replace(/</g, open)
-      .replace(/>/g, close);
+        .replace(/</g, open)
+        .replace(/>/g, close);
     return new RegExp(str);
   },
 
@@ -586,24 +595,15 @@ Template.prototype = {
     if (!this.source) {
       this.generateSource();
       prepended +=
-        '  var __output = "";\n' +
-        '  function __append(s) { if (s !== undefined && s !== null) __output += s }\n';
+          '  var __output = "";\n' +
+          '  function __append(s) { if (s !== undefined && s !== null) __output += s }\n';
       if (opts.outputFunctionName) {
-        if (!_JS_IDENTIFIER.test(opts.outputFunctionName)) {
-          throw new Error('outputFunctionName is not a valid JS identifier.');
-        }
         prepended += '  var ' + opts.outputFunctionName + ' = __append;' + '\n';
-      }
-      if (opts.localsName && !_JS_IDENTIFIER.test(opts.localsName)) {
-        throw new Error('localsName is not a valid JS identifier.');
       }
       if (opts.destructuredLocals && opts.destructuredLocals.length) {
         var destructuring = '  var __locals = (' + opts.localsName + ' || {}),\n';
         for (var i = 0; i < opts.destructuredLocals.length; i++) {
           var name = opts.destructuredLocals[i];
-          if (!_JS_IDENTIFIER.test(name)) {
-            throw new Error('destructuredLocals[' + i + '] is not a valid JS identifier.');
-          }
           if (i > 0) {
             destructuring += ',\n  ';
           }
@@ -621,13 +621,13 @@ Template.prototype = {
 
     if (opts.compileDebug) {
       src = 'var __line = 1' + '\n'
-        + '  , __lines = ' + JSON.stringify(this.templateText) + '\n'
-        + '  , __filename = ' + sanitizedFilename + ';' + '\n'
-        + 'try {' + '\n'
-        + this.source
-        + '} catch (e) {' + '\n'
-        + '  rethrow(e, __lines, __filename, __line, escapeFn);' + '\n'
-        + '}' + '\n';
+          + '  , __lines = ' + JSON.stringify(this.templateText) + '\n'
+          + '  , __filename = ' + sanitizedFilename + ';' + '\n'
+          + 'try {' + '\n'
+          + this.source
+          + '} catch (e) {' + '\n'
+          + '  rethrow(e, __lines, __filename, __line, escapeFn);' + '\n'
+          + '}' + '\n';
     }
     else {
       src = this.source;
@@ -648,7 +648,7 @@ Template.prototype = {
     }
     if (opts.compileDebug && opts.filename) {
       src = src + '\n'
-        + '//# sourceURL=' + sanitizedFilename + '\n';
+          + '//# sourceURL=' + sanitizedFilename + '\n';
     }
 
     try {
@@ -701,7 +701,7 @@ Template.prototype = {
         return includeFile(path, opts)(d);
       };
       return fn.apply(opts.context,
-        [data || utils.createNullProtoObjWherePossible(), escapeFn, include, rethrow]);
+          [data || utils.createNullProtoObjWherePossible(), escapeFn, include, rethrow]);
     };
     if (opts.filename && typeof Object.defineProperty === 'function') {
       var filename = opts.filename;
@@ -725,12 +725,12 @@ Template.prototype = {
       // Have to use two separate replace here as `^` and `$` operators don't
       // work well with `\r` and empty lines don't work well with the `m` flag.
       this.templateText =
-        this.templateText.replace(/[\r\n]+/g, '\n').replace(/^\s+|\s+$/gm, '');
+          this.templateText.replace(/[\r\n]+/g, '\n').replace(/^\s+|\s+$/gm, '');
     }
 
     // Slurp spaces and tabs before <%_ and after _%>
     this.templateText =
-      this.templateText.replace(/[ \t]*<%_/gm, '<%_').replace(/_%>[ \t]*/gm, '_%>');
+        this.templateText.replace(/[ \t]*<%_/gm, '<%_').replace(/_%>[ \t]*/gm, '_%>');
 
     var self = this;
     var matches = this.parseTemplateText();
@@ -746,7 +746,7 @@ Template.prototype = {
         // Better to store modes as k/v with openDelimiter + delimiter as key
         // Then this can simply check against the map
         if ( line.indexOf(o + d) === 0        // If it is a tag
-          && line.indexOf(o + d + d) !== 0) { // and is not escaped
+            && line.indexOf(o + d + d) !== 0) { // and is not escaped
           closing = matches[index + 2];
           if (!(closing == d + c || closing == '-' + d + c || closing == '_' + d + c)) {
             throw new Error('Could not find matching close tag for "' + line + '".');
@@ -822,75 +822,75 @@ Template.prototype = {
     newLineCount = (line.split('\n').length - 1);
 
     switch (line) {
-    case o + d:
-    case o + d + '_':
-      this.mode = Template.modes.EVAL;
-      break;
-    case o + d + '=':
-      this.mode = Template.modes.ESCAPED;
-      break;
-    case o + d + '-':
-      this.mode = Template.modes.RAW;
-      break;
-    case o + d + '#':
-      this.mode = Template.modes.COMMENT;
-      break;
-    case o + d + d:
-      this.mode = Template.modes.LITERAL;
-      this.source += '    ; __append("' + line.replace(o + d + d, o + d) + '")' + '\n';
-      break;
-    case d + d + c:
-      this.mode = Template.modes.LITERAL;
-      this.source += '    ; __append("' + line.replace(d + d + c, d + c) + '")' + '\n';
-      break;
-    case d + c:
-    case '-' + d + c:
-    case '_' + d + c:
-      if (this.mode == Template.modes.LITERAL) {
-        this._addOutput(line);
-      }
+      case o + d:
+      case o + d + '_':
+        this.mode = Template.modes.EVAL;
+        break;
+      case o + d + '=':
+        this.mode = Template.modes.ESCAPED;
+        break;
+      case o + d + '-':
+        this.mode = Template.modes.RAW;
+        break;
+      case o + d + '#':
+        this.mode = Template.modes.COMMENT;
+        break;
+      case o + d + d:
+        this.mode = Template.modes.LITERAL;
+        this.source += '    ; __append("' + line.replace(o + d + d, o + d) + '")' + '\n';
+        break;
+      case d + d + c:
+        this.mode = Template.modes.LITERAL;
+        this.source += '    ; __append("' + line.replace(d + d + c, d + c) + '")' + '\n';
+        break;
+      case d + c:
+      case '-' + d + c:
+      case '_' + d + c:
+        if (this.mode == Template.modes.LITERAL) {
+          this._addOutput(line);
+        }
 
-      this.mode = null;
-      this.truncate = line.indexOf('-') === 0 || line.indexOf('_') === 0;
-      break;
-    default:
-      // In script mode, depends on type of tag
-      if (this.mode) {
-        // If '//' is found without a line break, add a line break.
-        switch (this.mode) {
-        case Template.modes.EVAL:
-        case Template.modes.ESCAPED:
-        case Template.modes.RAW:
-          if (line.lastIndexOf('//') > line.lastIndexOf('\n')) {
-            line += '\n';
+        this.mode = null;
+        this.truncate = line.indexOf('-') === 0 || line.indexOf('_') === 0;
+        break;
+      default:
+        // In script mode, depends on type of tag
+        if (this.mode) {
+          // If '//' is found without a line break, add a line break.
+          switch (this.mode) {
+            case Template.modes.EVAL:
+            case Template.modes.ESCAPED:
+            case Template.modes.RAW:
+              if (line.lastIndexOf('//') > line.lastIndexOf('\n')) {
+                line += '\n';
+              }
+          }
+          switch (this.mode) {
+              // Just executing code
+            case Template.modes.EVAL:
+              this.source += '    ; ' + line + '\n';
+              break;
+              // Exec, esc, and output
+            case Template.modes.ESCAPED:
+              this.source += '    ; __append(escapeFn(' + stripSemi(line) + '))' + '\n';
+              break;
+              // Exec and output
+            case Template.modes.RAW:
+              this.source += '    ; __append(' + stripSemi(line) + ')' + '\n';
+              break;
+            case Template.modes.COMMENT:
+              // Do nothing
+              break;
+              // Literal <%% mode, append as raw output
+            case Template.modes.LITERAL:
+              this._addOutput(line);
+              break;
           }
         }
-        switch (this.mode) {
-        // Just executing code
-        case Template.modes.EVAL:
-          this.source += '    ; ' + line + '\n';
-          break;
-          // Exec, esc, and output
-        case Template.modes.ESCAPED:
-          this.source += '    ; __append(escapeFn(' + stripSemi(line) + '))' + '\n';
-          break;
-          // Exec and output
-        case Template.modes.RAW:
-          this.source += '    ; __append(' + stripSemi(line) + ')' + '\n';
-          break;
-        case Template.modes.COMMENT:
-          // Do nothing
-          break;
-          // Literal <%% mode, append as raw output
-        case Template.modes.LITERAL:
+        // In string mode, just add the output
+        else {
           this._addOutput(line);
-          break;
         }
-      }
-      // In string mode, just add the output
-      else {
-        this._addOutput(line);
-      }
     }
 
     if (self.opts.compileDebug && newLineCount) {


### PR DESCRIPTION
There are omissions in the regular matching repair method. Replace the regular matching repair method with a more concise, efficient and safe method, that is, traverse the prototype attribute of opts once and set it to undefined.
See lines 508 to 519 for details.