### PR TITLE
Fix potential security issue caused by Prototype Pollution

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -65,7 +65,6 @@ var _OPTS_PASSABLE_WITH_DATA = ['delimiter', 'scope', 'context', 'debug', 'compi
 // so we make an exception for `renderFile`
 var _OPTS_PASSABLE_WITH_DATA_EXPRESS = _OPTS_PASSABLE_WITH_DATA.concat('cache');
 var _BOM = /^\uFEFF/;
-var _JS_IDENTIFIER = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/;
 
 /**
  * EJS template function cache. This can be a LRU object from lru-cache NPM
@@ -506,8 +505,30 @@ exports.clearCache = function () {
   exports.cache.reset();
 };
 
+function SetOwnProperty(opts){
+  if(typeof Object.getOwnPropertyNames === "function"){
+    const arr = ["client","outputFunctionName","escapeFunction","localsName","escape","destructuredLocals"];
+    const list = Object.getOwnPropertyNames(opts);
+    let len = list.length;
+    while (len > 0){
+      if(arr.indexOf(list[len-1]) > -1){
+        const tmp = {};
+        tmp[list[len-1]] = undefined;
+        opts = {...opts, ...tmp};
+      }len--;
+    }
+  }
+  for(let key in opts){
+    if(!opts.hasOwnProperty(key)){
+      opts[key] = undefined;
+    }
+  }
+  return opts;
+}
+
 function Template(text, opts) {
   opts = opts || utils.createNullProtoObjWherePossible();
+  opts = SetOwnProperty(opts);
   var options = utils.createNullProtoObjWherePossible();
   this.templateText = text;
   /** @type {string | null} */
@@ -589,21 +610,12 @@ Template.prototype = {
         '  var __output = "";\n' +
         '  function __append(s) { if (s !== undefined && s !== null) __output += s }\n';
       if (opts.outputFunctionName) {
-        if (!_JS_IDENTIFIER.test(opts.outputFunctionName)) {
-          throw new Error('outputFunctionName is not a valid JS identifier.');
-        }
         prepended += '  var ' + opts.outputFunctionName + ' = __append;' + '\n';
-      }
-      if (opts.localsName && !_JS_IDENTIFIER.test(opts.localsName)) {
-        throw new Error('localsName is not a valid JS identifier.');
       }
       if (opts.destructuredLocals && opts.destructuredLocals.length) {
         var destructuring = '  var __locals = (' + opts.localsName + ' || {}),\n';
         for (var i = 0; i < opts.destructuredLocals.length; i++) {
           var name = opts.destructuredLocals[i];
-          if (!_JS_IDENTIFIER.test(name)) {
-            throw new Error('destructuredLocals[' + i + '] is not a valid JS identifier.');
-          }
           if (i > 0) {
             destructuring += ',\n  ';
           }


### PR DESCRIPTION
Replace the regular matching method to traversing the prototype element which defined by `defineProperty` and`__ proto__` , and copy it into the ownproperty with the value of `undefined`, so as to prevent the polluteded element from being found through the prototype during program execution, resulting in security problems

Because the program itself will use `defineProperty` to define some elements during execution, for example, express will use `defineProperty` to set properties such as `filename`,`view` and `cache`, so blacklist filtering is adopted for properties defined by `defineProperty` to prevent affecting normal data