### PR TITLE
Added async handling of the `includer`

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -872,11 +872,19 @@ Template.prototype = {
           break;
           // Exec, esc, and output
         case Template.modes.ESCAPED:
-          this.source += '    ; __append(escapeFn(' + stripSemi(line) + '))' + '\n';
+          if(this.opts.async) {
+            this.source += '    ; __append(escapeFn(await Promise.resolve(' + stripSemi(line) + ')))' + '\n';
+          } else {
+            this.source += '    ; __append(escapeFn(' + stripSemi(line) + '))' + '\n';
+          }
           break;
           // Exec and output
         case Template.modes.RAW:
-          this.source += '    ; __append(' + stripSemi(line) + ')' + '\n';
+          if(this.opts.async) {
+            this.source += '    ; __append(await Promise.resolve(' + stripSemi(line) + '))' + '\n';
+          } else {
+            this.source += '    ; __append(' + stripSemi(line) + ')' + '\n';
+          }
           break;
         case Template.modes.COMMENT:
           // Do nothing


### PR DESCRIPTION
This is a possible easy fix for the [issue ](https://github.com/mde/ejs/issues/708#issue-1516608462) I reported yesterday.

I am not sure if the typescript declarations gets updated automatically, or if that takes additional actions,
If more things are required to push this, feel free to ask.

