### PR TITLE
Make escapeXML work when the Function prototype is frozen

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -99,9 +99,14 @@ exports.escapeXML = function (markup) {
     : String(markup)
       .replace(_MATCH_HTML, encode_char);
 };
-exports.escapeXML.toString = function () {
+
+// If the Object prototype is frozen, the "toString" property is non-writable. This means that any objects which inherit this property
+// cannot have the property changed using an assignment. If using strict mode, attempting that will cause an error. If not using strict
+// mode, attempting that will be silently ignored.
+// However, we can still explicitly shadow the prototype's "toString" property by defining a new "toString" property on this object.
+Object.defineProperty(exports.escapeXML, 'toString', function () {
   return Function.prototype.toString.call(this) + ';\n' + escapeFuncStr;
-};
+});
 
 /**
  * Naive copy of properties from one object to another.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -100,13 +100,24 @@ exports.escapeXML = function (markup) {
       .replace(_MATCH_HTML, encode_char);
 };
 
-// If the Object prototype is frozen, the "toString" property is non-writable. This means that any objects which inherit this property
-// cannot have the property changed using an assignment. If using strict mode, attempting that will cause an error. If not using strict
-// mode, attempting that will be silently ignored.
-// However, we can still explicitly shadow the prototype's "toString" property by defining a new "toString" property on this object.
-Object.defineProperty(exports.escapeXML, 'toString', function () {
+function escapeXMLToString() {
   return Function.prototype.toString.call(this) + ';\n' + escapeFuncStr;
-});
+}
+
+try {
+  if (typeof Object.defineProperty === 'function') {
+  // If the Function prototype is frozen, the "toString" property is non-writable. This means that any objects which inherit this property
+  // cannot have the property changed using an assignment. If using strict mode, attempting that will cause an error. If not using strict
+  // mode, attempting that will be silently ignored.
+  // However, we can still explicitly shadow the prototype's "toString" property by defining a new "toString" property on this object.
+    Object.defineProperty(exports.escapeXML, 'toString', { value: escapeXMLToString });
+  } else {
+    // If Object.defineProperty() doesn't exist, attempt to shadow this property using the assignment operator.
+    exports.escapeXML.toString = escapeXMLToString;
+  }
+} catch (err) {
+  console.warn('Unable to set escapeXML.toString (is the Function prototype frozen?)');
+}
 
 /**
  * Naive copy of properties from one object to another.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha -u tdd"
   }
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -83,8 +83,27 @@ suite('unit testing exported functions of module \'utils.js\'', function () {
    */
   suite('unit testing function \'escapeXML\' of module \'utils.js\'', function () {
     test('it should be callable without parameters', function () {
+      const stringified =
+`function (markup) {
+  return markup == undefined
+    ? ''
+    : String(markup)
+      .replace(_MATCH_HTML, encode_char);
+};
+var _ENCODE_HTML_RULES = {
+      "&": "&amp;"
+    , "<": "&lt;"
+    , ">": "&gt;"
+    , '"': "&#34;"
+    , "'": "&#39;"
+    }
+  , _MATCH_HTML = /[&<>'"]/g;
+function encode_char(c) {
+  return _ENCODE_HTML_RULES[c] || c;
+};
+`;
       assert.doesNotThrow(() => { utils.escapeXML.toString(); });
-      assert.ok(typeof(utils.escapeXML.toString())==='string');
+      assert.ok(utils.escapeXML.toString()===stringified);
     });
   });
 


### PR DESCRIPTION
## Background

_Note: examples use the Node.js REPL with strict mode: `node --use_strict`._

### Inheritance and Shadowing

Objects in JavaScript [inherit properties from their prototype chain](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain). For example, the "toString" property can be accessed on all objects, but it doesn't actually exist on each object, it exists on the global Object prototype:

```js
let obj = {};
obj.toString();
// '[object Object]'
Object.getOwnPropertyDescriptor(obj, 'toString');
// undefined
Object.getOwnPropertyDescriptor(Object.prototype, 'toString');
// { value: [Function: toString], writable: true, enumerable: false, configurable: true }
```

Under normal circumstances, you can assign a property to an object using the `=` operator, and any property of the same name in the object's prototype chain will not be modified, but will be "[shadowed](https://en.wikipedia.org/wiki/Variable_shadowing)" by the new property:

```js
obj.toString = () => 'foo';
obj.toString();
// 'foo'
Object.getOwnPropertyDescriptor(obj, 'toString');
// { value: [Function: toString], writable: true, enumerable: true, configurable: true }
```

### Prototype Pollution

[From Snyk:](https://learn.snyk.io/lessons/prototype-pollution/javascript/)

> Prototype pollution is an injection attack that targets JavaScript runtimes. With prototype pollution, an attacker might control the default values of an object's properties. This allows the attacker to tamper with the logic of the application and can also lead to denial of service or, in extreme cases, remote code execution.

There are a few different ways to mitigate Prototype Pollution, and one way to do it across the board is to [freeze the global "root" objects and their prototypes (Object, Function, Array, etc.)](https://www.npmjs.com/package/nopp)

[From MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze):

> The `Object.freeze()` static method *freezes* an object. Freezing an object [prevents extensions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and makes existing properties non-writable and non-configurable. A frozen object can no longer be changed: new properties cannot be added, existing properties cannot be removed, their enumerability, configurability, writability, or value cannot be changed, and the object's prototype cannot be re-assigned.

This means that any attempt to change the Object prototype will fail. If using [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode), it will throw an error; otherwise, it will be silently ignored.

If the Object prototype becomes frozen, all of its properties are no longer writable or configurable:

```js
Object.freeze(Object.prototype);
Object.getOwnPropertyDescriptor(Object.prototype, 'toString');
// { value: [Function: toString], writable: false, enumerable: false, configurable: false }
```

This also prevents shadowing properties with assignment. If an object _doesn't_ already have a property defined (such as "toString"), **and** it inherits a _non-writable_ property of that name from its prototype chain, any attempt to assign the property on that object will fail:

```js
let obj2 = {};
obj2.toString = () => 'bar';
// Uncaught TypeError: Cannot assign to read only property 'toString' of object '#<Object>'
obj2.toString();
// '[object Object]'
```

This behavior is described in the [ECMAScript 2016 specification](https://262.ecma-international.org/7.0/#sec-strict-mode-of-ecmascript):

> Assignment to an undeclared identifier or otherwise unresolvable reference does not create a property in the [global object](https://262.ecma-international.org/7.0/#global-object). When a simple assignment occurs within [strict mode code](https://262.ecma-international.org/7.0/#sec-strict-mode-code), its [LeftHandSideExpression](https://262.ecma-international.org/7.0/#prod-LeftHandSideExpression) must not evaluate to an unresolvable [Reference](https://262.ecma-international.org/7.0/#sec-reference-specification-type). If it does a **ReferenceError** exception is thrown ([6.2.3.2](https://262.ecma-international.org/7.0/#sec-putvalue)). The [LeftHandSideExpression](https://262.ecma-international.org/7.0/#prod-LeftHandSideExpression) also may not be a reference to a data property with the attribute value {[[Writable]]: **false**}, to an accessor property with the attribute value {[[Set]]: **undefined**}, nor to a non-existent property of an object whose [[Extensible]] internal slot has the value **false**. In these cases a `TypeError` exception is thrown ([12.15](https://262.ecma-international.org/7.0/#sec-assignment-operators)).

## The Problem

Unfortunately, this package uses assignment to shadow the "toString" function on the escapeXML function:

https://github.com/mde/ejs/blob/f818bce2a5b72866f205c9284e8257f2b155aa66/lib/utils.js#L102-L104

This means that projects cannot require this package if they have frozen the global Function prototype.

## The Solution

You can still shadow non-writable prototype properties by explicitly defining a new data property on the object:

```js
Object.defineProperty(obj2, 'toString', { value: () => 'bar' });
obj2.toString();
// 'bar'
Object.getOwnPropertyDescriptor(obj2, 'toString');
// { value: [Function: toString], writable: false, enumerable: false, configurable: false }
```

The escapeXML function can be changed to use this method of shadowing so it is compatible with this approach of mitigating Prototype Pollution 🎉