### PR TITLE
feat: use globalThis shim

### DIFF
--- a/lib/ejs.js
+++ b/lib/ejs.js
@@ -49,6 +49,7 @@ var fs = require('fs');
 var path = require('path');
 var utils = require('./utils');
 
+var GLOBAL_THIS = typeof globalThis !== 'undefined' ? globalThis : (new Function('return this;'))();
 var scopeOptionWarned = false;
 /** @type {string} */
 var _VERSION_STRING = require('../package.json').version;
@@ -106,7 +107,7 @@ exports.localsName = _DEFAULT_LOCALS_NAME;
  * @public
  */
 
-exports.promiseImpl = (new Function('return this;'))().Promise;
+exports.promiseImpl = GLOBAL_THIS.Promise;
 
 /**
  * Get the path to the included file from the parent file path and the


### PR DESCRIPTION
This supports environments like https://hardenedjs.org/ that support `globalThis` but do not support getting the global object via the Function constructor.