### PR TITLE
refactor(cli): migrate from jake to minimist for argument parsing

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -94,21 +94,25 @@ function run() {
     process.exit(0);
   }
 
-  const templatePath = argv._[0];
-  // Ensure there's a template to render, throw if not
+  // Parse out any environment variables passed after the template path
+  // Based on jake parseArgs envVars implementation to ensure non-breaking changes in jake migration
+  // @see https://github.com/jakejs/jake/blob/main/lib/parseargs.js#L111
+  let envVars = {};
+  let templatePaths = [];
+  argv._.map(v => v.split('=')).forEach(pair => {
+    if (pair.length > 1) {
+      envVars[pair[0]] = pair[1];
+    } else {
+      templatePaths.push(pair[0]);
+    }
+  });
+
+  // Template path is always is first positional argument without "="
+  // Template path is required and we will throw an error if it is not provided
+  let templatePath = templatePaths[0];
   if (!templatePath) {
     throw new Error('Please provide a template path. (Run ejs -h for help)');
   }
-
-  // Parse out any environment variables passed after the template path
-  // Based on jake parseArgs envVars implementation
-  // @see https://github.com/jakejs/jake/blob/main/lib/parseargs.js#L111
-  let envVars = {};
-  argv._.slice(1).map(v => v.split('=')).forEach(pair => {
-    if (pair.length > 1) {
-      envVars[pair[0]] = pair[1];
-    }
-  });
 
   // Grab and parse any input data, in order of precedence:
   // 1. Stdin

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -148,6 +148,11 @@ function run() {
     vals[p] = envVars[p];
   }
 
+  // strict implies no-with
+  if (argv['strict']) {
+    argv['no-with'] = true;
+  }
+
   let opts = {
     filename: path.resolve(process.cwd(), templatePath),
     rmWhitespace: argv['rm-whitespace'],
@@ -157,13 +162,8 @@ function run() {
     delimiter: argv['delimiter'],
     openDelimiter: argv['open-delimiter'],
     closeDelimiter: argv['close-delimiter'],
+    _with: !argv['no-with'],
   };
-  if (opts['strict']) {
-    opts.noWith = true;
-  }
-  if (argv['no-with']) {
-    opts._with = false;
-  }
 
   let template = fs.readFileSync(opts.filename).toString();
   let output = ejs.render(template, vals, opts);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,98 +16,10 @@
  * limitations under the License.
  *
 */
-
-let path = require('path');
-
-let program = require('jake').program;
-delete global.jake; // NO NOT WANT
-program.setTaskNames = function (n) { this.taskNames = n; };
-
-let ejs = require('../lib/ejs');
-let { hyphenToCamel } = require('../lib/utils');
+let parseArgs = require('minimist');
 let fs = require('fs');
-let args = process.argv.slice(2);
-let usage = fs.readFileSync(`${__dirname}/../usage.txt`).toString();
-
-const CLI_OPTS = [
-  { full: 'output-file',
-    abbr: 'o',
-    expectValue: true,
-  },
-  { full: 'data-file',
-    abbr: 'f',
-    expectValue: true,
-  },
-  { full: 'data-input',
-    abbr: 'i',
-    expectValue: true,
-  },
-  { full: 'delimiter',
-    abbr: 'm',
-    expectValue: true,
-    passThrough: true,
-  },
-  { full: 'open-delimiter',
-    abbr: 'p',
-    expectValue: true,
-    passThrough: true,
-  },
-  { full: 'close-delimiter',
-    abbr: 'c',
-    expectValue: true,
-    passThrough: true,
-  },
-  { full: 'strict',
-    abbr: 's',
-    expectValue: false,
-    allowValue: false,
-    passThrough: true,
-  },
-  { full: 'no-with',
-    abbr: 'n',
-    expectValue: false,
-    allowValue: false,
-  },
-  { full: 'locals-name',
-    abbr: 'l',
-    expectValue: true,
-    passThrough: true,
-  },
-  { full: 'rm-whitespace',
-    abbr: 'w',
-    expectValue: false,
-    allowValue: false,
-    passThrough: true,
-  },
-  { full: 'debug',
-    abbr: 'd',
-    expectValue: false,
-    allowValue: false,
-    passThrough: true,
-  },
-  { full: 'help',
-    abbr: 'h',
-    passThrough: true,
-  },
-  { full: 'version',
-    abbr: 'V',
-    passThrough: true,
-  },
-  // Alias lowercase v
-  { full: 'version',
-    abbr: 'v',
-    passThrough: true,
-  },
-];
-
-let preempts = {
-  version: function () {
-    program.die(ejs.VERSION);
-  },
-  help: function () {
-    program.die(usage);
-  }
-};
+let path = require('path');
+let ejs = require('../lib/ejs');
 
 let stdin = '';
 process.stdin.setEncoding('utf8');
@@ -118,49 +30,85 @@ process.stdin.on('readable', () => {
   }
 });
 
+function printUsage() {
+  const usagePath = path.join(__dirname, '../usage.txt');
+  let usageText = fs.readFileSync(usagePath).toString();
+  console.log(usageText);
+}
+
+function printVersion() {
+  console.log(ejs.VERSION);
+}
+
+
 function run() {
-
-  program.availableOpts = CLI_OPTS;
-  program.parseArgs(args);
-
-  let templatePath = program.taskNames[0];
-  let pVals = program.envVars;
-  let pOpts = {};
-
-  for (let p in program.opts) {
-    let name = hyphenToCamel(p);
-    pOpts[name] = program.opts[p];
-  }
-
-  let opts = {};
-  let vals = {};
-
-  // Same-named 'passthrough' opts
-  CLI_OPTS.forEach((opt) => {
-    let optName = hyphenToCamel(opt.full);
-    if (opt.passThrough && typeof pOpts[optName] != 'undefined') {
-      opts[optName] = pOpts[optName];
+  let args = process.argv.slice(2);
+  let argv = parseArgs(args, {
+    alias: {
+      'o': 'output-file',
+      'f': 'data-file',
+      'i': 'data-input',
+      'm': 'delimiter',
+      'p': 'open-delimiter',
+      'c': 'close-delimiter',
+      's': 'strict',
+      'n': 'no-with',
+      'l': 'locals-name',
+      'w': 'rm-whitespace',
+      'd': 'debug',
+      'h': 'help',
+      'V': 'version',
+      'v': 'version',
+    },
+    boolean: [
+      'help',
+      'version',
+      'debug',
+      'rm-whitespace',
+      'strict',
+      'no-with'
+    ],
+    string: [
+      'output-file',
+      'data-file',
+      'data-input',
+      'delimiter',
+      'open-delimiter',
+      'close-delimiter',
+      'locals-name'
+    ],
+    default: {
+      'delimiter': '%',
+      'close-delimiter': '>',
+      'open-delimiter': '<',
     }
   });
 
-  // Bail out for help/version
-  for (let p in opts) {
-    if (preempts[p]) {
-      return preempts[p]();
-    }
+
+  if (argv.help) {
+    printUsage();
+    process.exit(0);
+  }
+  if (argv.version) {
+    printVersion();
+    process.exit(0);
   }
 
-  // Ensure there's a template to render
+  const templatePath = argv._[0];
+  // Ensure there's a template to render, throw if not
   if (!templatePath) {
     throw new Error('Please provide a template path. (Run ejs -h for help)');
   }
 
-  if (opts.strict) {
-    pOpts.noWith = true;
-  }
-  if (pOpts.noWith) {
-    opts._with = false;
-  }
+  // Parse out any environment variables passed after the template path
+  // Based on jake parseArgs envVars implementation
+  // @see https://github.com/jakejs/jake/blob/main/lib/parseargs.js#L111
+  let envVars = {};
+  argv._.slice(1).map(v => v.split('=')).forEach(pair => {
+    if (pair.length > 1) {
+      envVars[pair[0]] = pair[1];
+    }
+  });
 
   // Grab and parse any input data, in order of precedence:
   // 1. Stdin
@@ -173,38 +121,63 @@ function run() {
   if (stdin) {
     input = stdin;
   }
-  else if (pOpts.dataInput) {
+  else if (argv['data-input']) {
+    if(Array.isArray(argv['data-input'])) {
+      throw new Error('Please provide a single string for data input. (Run ejs -h for help)');
+    }
     if (input) {
       throw err;
     }
-    input = decodeURIComponent(pOpts.dataInput);
+    input = decodeURIComponent(argv['data-input']);
   }
-  else if (pOpts.dataFile) {
+  else if (argv['data-file']) {
+    if (Array.isArray(argv['data-file'])) {
+      throw new Error('Please provide a single string for data file. (Run ejs -h for help)');
+    }
     if (input) {
       throw err;
     }
-    input = fs.readFileSync(pOpts.dataFile).toString();
+    input = fs.readFileSync(argv['data-file']).toString();
   }
-
+  let vals = {};
   if (input) {
     vals = JSON.parse(input);
   }
-
-  // Override / set any individual values passed from the command line
-  for (let p in pVals) {
-    vals[p] = pVals[p];
+  // Override set any individual values passed from the command line
+  for (let p in envVars) {
+    vals[p] = envVars[p];
   }
 
-  opts.filename = path.resolve(process.cwd(), templatePath);
+  let opts = {
+    filename: path.resolve(process.cwd(), templatePath),
+    rmWhitespace: argv['rm-whitespace'],
+    strict: argv['strict'],
+    debug: argv['debug'],
+    localsName: argv['locals-name'],
+    delimiter: argv['delimiter'],
+    openDelimiter: argv['open-delimiter'],
+    closeDelimiter: argv['close-delimiter'],
+  };
+  if (opts['strict']) {
+    opts.noWith = true;
+  }
+  if (argv['no-with']) {
+    opts._with = false;
+  }
+
   let template = fs.readFileSync(opts.filename).toString();
   let output = ejs.render(template, vals, opts);
-  if (pOpts.outputFile) {
-    fs.writeFileSync(pOpts.outputFile, output);
+  if (argv['output-file']) {
+    if (Array.isArray(argv['output-file'])) {
+      throw new Error('Please provide a single string for output file. (Run ejs -h for help)');
+    }
+    fs.writeFileSync(argv['output-file'], output);
   }
   else {
     process.stdout.write(output);
   }
-  process.exit();
+  process.exit(0);
+
 }
 
 // Defer execution so that stdin can be read if necessary

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "bugs": "https://github.com/mde/ejs/issues",
   "homepage": "https://github.com/mde/ejs",
   "dependencies": {
-    "jake": "^10.8.5"
+    "minimist": "^1.2.8"
   },
   "devDependencies": {
     "browserify": "^16.5.1",
@@ -31,7 +31,8 @@
     "jsdoc": "^4.0.2",
     "lru-cache": "^4.0.1",
     "mocha": "^10.2.0",
-    "uglify-js": "^3.3.16"
+    "uglify-js": "^3.3.16", 
+    "jake": "^10.8.5"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
- Replace jake.program with minimist for CLI argument parsing
- Add minimist dependency to package.json
- Improve error handling for conflicting data input methods
- Simplify option parsing with explicit alias and type definitions
- Maintain backward compatibility with existing CLI interface

BREAKING CHANGE: None - CLI interface remains the same

Why minimist
- very popular module
- zero dependencies
- well tested and maintained
- have support for old node.js versions "node": ">= 0.4"

This would eliminate large dependacy tree comming from jake
![image](https://github.com/user-attachments/assets/fb033113-14ed-44c6-ac34-f2e3fc8b5230)

Fixes:
https://github.com/mde/ejs/issues/786
https://github.com/mde/ejs/issues/744
https://github.com/mde/ejs/issues/510
https://github.com/mde/ejs/issues/659

Might help with
https://github.com/mde/ejs/issues/518 this would reduce amount of packages installed and potential compact issues.
https://github.com/mde/ejs/issues/690 we could use minimist unknown option to easily implement this.


Supersede 
https://github.com/mde/ejs/pull/645 previous attempt stalled because of to lack of parser test.
