### PR TITLE
fix: prevent with() variable shadowing of internal functions

### DIFF
--- a/lib/esm/ejs.js
+++ b/lib/esm/ejs.js
@@ -578,13 +578,13 @@ Template.prototype = {
     if (!this.source) {
       this.generateSource();
       prepended +=
-        `  ${DECLARATION_KEYWORD} __output = "";\n` +
-        '  function __append(s) { if (s !== undefined && s !== null) __output += s }\n';
+        `  ${DECLARATION_KEYWORD} __ejs_output = "";\n` +
+        '  function __ejs_append(s) { if (s !== undefined && s !== null) __ejs_output += s }\n';
       if (opts.outputFunctionName) {
         if (!_JS_IDENTIFIER.test(opts.outputFunctionName)) {
           throw new Error('outputFunctionName is not a valid JS identifier.');
         }
-        prepended += `  ${DECLARATION_KEYWORD} ` + opts.outputFunctionName + ' = __append;' + '\n';
+        prepended += `  ${DECLARATION_KEYWORD} ` + opts.outputFunctionName + ' = __ejs_append;' + '\n';
       }
       if (opts.localsName && !_JS_IDENTIFIER.test(opts.localsName)) {
         throw new Error('localsName is not a valid JS identifier.');
@@ -605,9 +605,13 @@ Template.prototype = {
       }
       if (opts._with !== false) {
         prepended +=  '  with (' + opts.localsName + ' || {}) {' + '\n';
+        // Re-export include as a let binding inside the with() block so that
+        // it cannot be shadowed by data properties (let bindings take
+        // precedence over with() scope). See GH-803.
+        prepended += `    ${DECLARATION_KEYWORD} include = __ejs_include;\n`;
         appended += '  }' + '\n';
       }
-      appended += '  return __output;' + '\n';
+      appended += '  return __ejs_output;' + '\n';
       this.source = prepended + this.source + appended;
     }
 
@@ -618,7 +622,7 @@ Template.prototype = {
         + 'try {' + '\n'
         + this.source
         + '} catch (e) {' + '\n'
-        + '  rethrow(e, __lines, __filename, __line, escapeFn);' + '\n'
+        + '  __ejs_rethrow(e, __lines, __filename, __line, __ejs_escapeFn);' + '\n'
         + '}' + '\n';
     }
     else {
@@ -655,7 +659,7 @@ Template.prototype = {
       else {
         ctor = Function;
       }
-      fn = new ctor(opts.localsName + ', escapeFn, include, rethrow', src);
+      fn = new ctor(opts.localsName + ', __ejs_escapeFn, __ejs_include, __ejs_rethrow', src);
     }
     catch(e) {
       // istanbul ignore else
@@ -801,7 +805,7 @@ Template.prototype = {
     // Escape double-quotes
     // - this will be the delimiter during execution
     line = line.replace(/"/g, '\\"');
-    this.source += '    ; __append("' + line + '")' + '\n';
+    this.source += '    ; __ejs_append("' + line + '")' + '\n';
   },
 
   scanLine: function (line) {
@@ -829,11 +833,11 @@ Template.prototype = {
       break;
     case o + d + d:
       this.mode = Template.modes.LITERAL;
-      this.source += '    ; __append("' + line.replace(o + d + d, o + d) + '")' + '\n';
+      this.source += '    ; __ejs_append("' + line.replace(o + d + d, o + d) + '")' + '\n';
       break;
     case d + d + c:
       this.mode = Template.modes.LITERAL;
-      this.source += '    ; __append("' + line.replace(d + d + c, d + c) + '")' + '\n';
+      this.source += '    ; __ejs_append("' + line.replace(d + d + c, d + c) + '")' + '\n';
       break;
     case d + c:
     case '-' + d + c:
@@ -864,11 +868,11 @@ Template.prototype = {
           break;
           // Exec, esc, and output
         case Template.modes.ESCAPED:
-          this.source += '    ; __append(escapeFn(' + stripSemi(line) + '))' + '\n';
+          this.source += '    ; __ejs_append(__ejs_escapeFn(' + stripSemi(line) + '))' + '\n';
           break;
           // Exec and output
         case Template.modes.RAW:
-          this.source += '    ; __append(' + stripSemi(line) + ')' + '\n';
+          this.source += '    ; __ejs_append(' + stripSemi(line) + ')' + '\n';
           break;
         case Template.modes.COMMENT:
           // Do nothing

--- a/test/ejs.js
+++ b/test/ejs.js
@@ -643,6 +643,28 @@ suite('<%=', function () {
       'THE JONES\'S'
     );
   });
+
+  test('should not allow data properties to shadow escapeFn (GH-803)', function () {
+    // If data.escapeFn could shadow the internal escape function,
+    // setting it to String would bypass HTML escaping
+    var output = ejs.render('<%= userInput %>', {
+      userInput: '<script>alert(1)</script>',
+      escapeFn: String
+    });
+    assert.equal(output, '&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  test('should not allow data properties to shadow include or rethrow (GH-803)', function () {
+    // Ensure other internal names are also not shadowable
+    var output = ejs.render('<%= val %>', {
+      val: '<img onerror=alert(1)>',
+      include: 'evil',
+      rethrow: 'evil',
+      __output: 'evil',
+      __append: 'evil'
+    });
+    assert.equal(output, '&lt;img onerror=alert(1)&gt;');
+  });
 });
 
 suite('<%-', function () {


### PR DESCRIPTION
## Summary

Fixes #803 - XSS escape bypass via `with()` variable shadowing of `escapeFn`.

When `_with` is enabled (the default), the `with(locals || {})` wrapper allows template data properties to shadow internal function parameters like `escapeFn`, `include`, `rethrow`, `__output`, and `__append`. Setting `data.escapeFn = String` bypasses all HTML escaping on `<%= %>` tags, enabling XSS.

### Changes

- Rename internal generated-code variables to collision-resistant names:
  - `escapeFn` -> `__ejs_escapeFn`
  - `__output` -> `__ejs_output`
  - `__append` -> `__ejs_append`
  - `rethrow` -> `__ejs_rethrow`
- Re-export `include` as a `let` binding inside the `with()` block, which takes precedence over `with()` scope per the JS spec (lexical declarations cannot be shadowed by `with`)
- Add two test cases verifying that `data.escapeFn = String` does NOT bypass HTML escaping, and that other internal names (`include`, `rethrow`, `__output`, `__append`) cannot be shadowed either

### Reproduction (before fix)

```js
const ejs = require('ejs');
const output = ejs.render('<%= userInput %>', {
  userInput: '<script>alert(1)</script>',
  escapeFn: String  // shadows the real escapeFn
});
// output contains unescaped <script> tags -- XSS!
```

### After fix

The above now correctly produces `&lt;script&gt;alert(1)&lt;/script&gt;`.

## Test plan

- [x] All 162 existing tests pass
- [x] New test: `data.escapeFn = String` does not bypass escaping
- [x] New test: `data.include`, `data.rethrow`, `data.__output`, `data.__append` do not break rendering